### PR TITLE
set blockHash when init CommitStateDB

### DIFF
--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -63,8 +63,8 @@ func handleMsgEthereumTx(ctx sdk.Context, k Keeper, msg types.MsgEthereumTx) (*s
 	// other nodes, causing a consensus error
 	if !st.Simulate {
 		// Prepare db for logs
-		// TODO: block hash
-		k.CommitStateDB.Prepare(ethHash, common.Hash{}, k.TxCount)
+		blockHash := types.HashFromContext(ctx)
+		k.CommitStateDB.Prepare(ethHash, blockHash, k.TxCount)
 		k.TxCount++
 	}
 
@@ -149,7 +149,8 @@ func handleMsgEthermint(ctx sdk.Context, k Keeper, msg types.MsgEthermint) (*sdk
 
 	if !st.Simulate {
 		// Prepare db for logs
-		k.CommitStateDB.Prepare(ethHash, common.Hash{}, k.TxCount)
+		blockHash := types.HashFromContext(ctx)
+		k.CommitStateDB.Prepare(ethHash, blockHash, k.TxCount)
 		k.TxCount++
 	}
 


### PR DESCRIPTION
From： https://github.com/cosmos/ethermint/pull/666

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
