### PR TITLE
Use value copy instead of pointer copy in stateObject.deepCopy

### DIFF
--- a/x/evm/types/state_object.go
+++ b/x/evm/types/state_object.go
@@ -392,7 +392,16 @@ func (so *stateObject) GetCommittedState(_ ethstate.Database, key ethcmn.Hash) e
 func (so *stateObject) ReturnGas(gas *big.Int) {}
 
 func (so *stateObject) deepCopy(db *CommitStateDB) *stateObject {
-	newStateObj := newStateObject(db, so.account)
+	newAccount := types.ProtoAccount().(*types.EthAccount)
+	jsonAccount, err := so.account.MarshalJSON()
+	if err != nil {
+		return nil
+	}
+	err = newAccount.UnmarshalJSON(jsonAccount)
+	if err != nil {
+		return nil
+	}
+	newStateObj := newStateObject(db, newAccount)
 
 	newStateObj.code = so.code
 	newStateObj.dirtyStorage = so.dirtyStorage.Copy()


### PR DESCRIPTION
From：https://github.com/cosmos/ethermint/pull/741

Close: https://github.com/cosmos/ethermint/issues/740

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
