### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.17
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout

--- a/.github/workflows/ci-iavl-ut.yml
+++ b/.github/workflows/ci-iavl-ut.yml
@@ -1,4 +1,4 @@
-name: iavl-ut 
+name: iavl-ut
 
 on:
   push:
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - name: test & coverage report creation
         run: |
           go test ./libs/iavl/...

--- a/app/repair_state.go
+++ b/app/repair_state.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -211,7 +210,7 @@ func latestBlockHeight(dataDir string) int64 {
 }
 
 func rmLockByDir(dataDir string) {
-	files, _ := ioutil.ReadDir(dataDir)
+	files, _ := os.ReadDir(dataDir)
 	for _, f := range files {
 		if f.IsDir() {
 			os.Remove(filepath.Join(dataDir, f.Name(), "LOCK"))

--- a/app/rpc/websockets/server.go
+++ b/app/rpc/websockets/server.go
@@ -4,23 +4,23 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"strings"
 	"sync"
 
-	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
-	"github.com/okex/exchain/libs/cosmos-sdk/server"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/prometheus"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
+	"github.com/okex/exchain/libs/cosmos-sdk/server"
+	"github.com/okex/exchain/libs/tendermint/libs/log"
 	"github.com/okex/exchain/x/common/monitor"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
-	"github.com/okex/exchain/libs/tendermint/libs/log"
 )
 
 // Server defines a server that handles Ethereum websockets.
@@ -266,7 +266,7 @@ func (s *Server) tcpGetAndSendResponse(conn *wsConn, mb []byte) error {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("could not read body from response; %s", err)
 	}

--- a/cmd/client/export.go
+++ b/cmd/client/export.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -16,12 +15,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/okex/exchain/app/crypto/ethsecp256k1"
+	"github.com/okex/exchain/app/crypto/hd"
 	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
 	"github.com/okex/exchain/libs/cosmos-sdk/client/input"
 	"github.com/okex/exchain/libs/cosmos-sdk/crypto/keys"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
-	"github.com/okex/exchain/app/crypto/ethsecp256k1"
-	"github.com/okex/exchain/app/crypto/hd"
 )
 
 // UnsafeExportEthKeyCommand exports a key with the given name as a private key in hex format.
@@ -181,7 +180,7 @@ func exportKeyStoreFile(ethKey *keystore.Key, encryptPassword, fileName string) 
 	}
 
 	// Write to keystore file
-	err = ioutil.WriteFile(fileName, content, os.ModePerm)
+	err = os.WriteFile(fileName, content, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to write keystore: %s", err.Error())
 	}

--- a/cmd/exchaind/data.go
+++ b/cmd/exchaind/data.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -23,13 +22,13 @@ import (
 	"github.com/okex/exchain/libs/cosmos-sdk/x/mint"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/supply"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/upgrade"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/syndtr/goleveldb/leveldb/util"
 	cfg "github.com/okex/exchain/libs/tendermint/config"
 	"github.com/okex/exchain/libs/tendermint/node"
 	sm "github.com/okex/exchain/libs/tendermint/state"
 	"github.com/okex/exchain/libs/tendermint/store"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/syndtr/goleveldb/leveldb/util"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/okex/exchain/x/ammswap"
@@ -259,7 +258,7 @@ func dbConvertCmd(ctx *server.Context) *cobra.Command {
 				}
 			}
 
-			fromFs, err := ioutil.ReadDir(fromDir)
+			fromFs, err := os.ReadDir(fromDir)
 			if err != nil {
 				return err
 			}

--- a/dev/client/common.go
+++ b/dev/client/common.go
@@ -5,6 +5,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -14,11 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/okex/exchain-ethereum-compatible/utils"
-
-	"io/ioutil"
-	"log"
-	"math/big"
-	"time"
 )
 
 const (
@@ -45,13 +45,13 @@ func newContract(name, address, abiFile string, byteCodeFile string) *Contract {
 		address: address,
 	}
 
-	bin, err := ioutil.ReadFile(byteCodeFile)
+	bin, err := os.ReadFile(byteCodeFile)
 	if err != nil {
 		log.Fatal(err)
 	}
 	c.byteCode = common.Hex2Bytes(string(bin))
 
-	abiByte, err := ioutil.ReadFile(abiFile)
+	abiByte, err := os.ReadFile(abiFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/libs/cosmos-sdk/baseapp/baseapp.go
+++ b/libs/cosmos-sdk/baseapp/baseapp.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"runtime/debug"
@@ -335,7 +334,7 @@ func UpgradeableStoreLoader(upgradeInfoPath string) StoreLoader {
 		}
 
 		// there is a migration file, let's execute
-		data, err := ioutil.ReadFile(upgradeInfoPath)
+		data, err := os.ReadFile(upgradeInfoPath)
 		if err != nil {
 			return fmt.Errorf("cannot read upgrade file %s: %v", upgradeInfoPath, err)
 		}

--- a/libs/cosmos-sdk/baseapp/baseapp_test.go
+++ b/libs/cosmos-sdk/baseapp/baseapp_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"github.com/okex/exchain/libs/iavl"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"sync"
@@ -189,7 +188,7 @@ func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte
 // Test that LoadLatestVersion actually does.
 func TestSetLoader(t *testing.T) {
 	// write a renamer to a file
-	f, err := ioutil.TempFile("", "upgrade-*.json")
+	f, err := os.CreateTemp("", "upgrade-*.json")
 	require.NoError(t, err)
 	data := []byte(`{"renamed":[{"old_key": "bnk", "new_key": "banker"}]}`)
 	_, err = f.Write(data)

--- a/libs/cosmos-sdk/client/config.go
+++ b/libs/cosmos-sdk/client/config.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -138,7 +137,7 @@ func loadConfigFile(cfgFile string) (*toml.Tree, error) {
 		return toml.Load(``)
 	}
 
-	bz, err := ioutil.ReadFile(cfgFile)
+	bz, err := os.ReadFile(cfgFile)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/cosmos-sdk/client/config_test.go
+++ b/libs/cosmos-sdk/client/config_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func Test_runConfigCmdTwiceWithShorterNodeValue(t *testing.T) {
 }
 
 func tmpDir(t *testing.T) (string, func()) {
-	dir, err := ioutil.TempDir("", t.Name()+"_")
+	dir, err := os.MkdirTemp("", t.Name()+"_")
 	require.NoError(t, err)
 	return dir, func() { _ = os.RemoveAll(dir) }
 }

--- a/libs/cosmos-sdk/client/context/verifier_test.go
+++ b/libs/cosmos-sdk/client/context/verifier_test.go
@@ -1,7 +1,7 @@
 package context_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCreateVerifier(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "example")
+	tmpDir, err := os.MkdirTemp("", "example")
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/libs/cosmos-sdk/client/keys/import.go
+++ b/libs/cosmos-sdk/client/keys/import.go
@@ -2,7 +2,7 @@ package keys
 
 import (
 	"bufio"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,7 +31,7 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	bz, err := ioutil.ReadFile(args[1])
+	bz, err := os.ReadFile(args[1])
 	if err != nil {
 		return err
 	}

--- a/libs/cosmos-sdk/client/keys/import_test.go
+++ b/libs/cosmos-sdk/client/keys/import_test.go
@@ -1,7 +1,7 @@
 package keys
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +42,7 @@ HbP+c6JmeJy9JXe2rbbF1QtCX1gLqGcDQPBXiCtFvP7/8wTZtVOPj8vREzhZ9ElO
 =f3l4
 -----END TENDERMINT PRIVATE KEY-----
 `
-	require.NoError(t, ioutil.WriteFile(keyfile, []byte(armoredKey), 0600))
+	require.NoError(t, os.WriteFile(keyfile, []byte(armoredKey), 0600))
 
 	// Now enter password
 	if runningUnattended {

--- a/libs/cosmos-sdk/client/keys/migrate.go
+++ b/libs/cosmos-sdk/client/keys/migrate.go
@@ -3,7 +3,6 @@ package keys
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
@@ -63,7 +62,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 	)
 
 	if viper.GetBool(flags.FlagDryRun) {
-		tmpDir, err = ioutil.TempDir("", "keybase-migrate-dryrun")
+		tmpDir, err = os.MkdirTemp("", "keybase-migrate-dryrun")
 		if err != nil {
 			return errors.Wrap(err, "failed to create temporary directory for dryrun migration")
 		}

--- a/libs/cosmos-sdk/crypto/keys/hd/fundraiser_test.go
+++ b/libs/cosmos-sdk/crypto/keys/hd/fundraiser_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,7 +33,7 @@ func initFundraiserTestVectors(t *testing.T) []addrData {
 	// var hdPath string = "m/44'/118'/0'/0/0"
 	var hdToAddrTable []addrData
 
-	b, err := ioutil.ReadFile("test.json")
+	b, err := os.ReadFile("test.json")
 	if err != nil {
 		t.Fatalf("could not read fundraiser test vector file (test.json): %s", err)
 	}

--- a/libs/cosmos-sdk/crypto/keys/keyring.go
+++ b/libs/cosmos-sdk/crypto/keys/keyring.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,9 +13,9 @@ import (
 	"github.com/99designs/keyring"
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/crypto/bcrypt"
 	tmcrypto "github.com/okex/exchain/libs/tendermint/crypto"
 	cryptoAmino "github.com/okex/exchain/libs/tendermint/crypto/encoding/amino"
+	"github.com/tendermint/crypto/bcrypt"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/input"
 	"github.com/okex/exchain/libs/cosmos-sdk/crypto/keys/keyerror"
@@ -544,7 +543,7 @@ func newRealPrompt(dir string, buf io.Reader) func(string) (string, error) {
 		_, err := os.Stat(keyhashFilePath)
 		switch {
 		case err == nil:
-			keyhash, err = ioutil.ReadFile(keyhashFilePath)
+			keyhash, err = os.ReadFile(keyhashFilePath)
 			if err != nil {
 				return "", fmt.Errorf("failed to read %s: %v", keyhashFilePath, err)
 			}
@@ -598,7 +597,7 @@ func newRealPrompt(dir string, buf io.Reader) func(string) (string, error) {
 				continue
 			}
 
-			if err := ioutil.WriteFile(dir+"/keyhash", passwordHash, 0555); err != nil {
+			if err := os.WriteFile(dir+"/keyhash", passwordHash, 0555); err != nil {
 				return "", err
 			}
 

--- a/libs/cosmos-sdk/server/export.go
+++ b/libs/cosmos-sdk/server/export.go
@@ -4,12 +4,11 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
+	tmtypes "github.com/okex/exchain/libs/tendermint/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	tmtypes "github.com/okex/exchain/libs/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
@@ -46,7 +45,7 @@ func ExportCmd(ctx *Context, cdc *codec.Codec, appExporter AppExporter) *cobra.C
 					return err
 				}
 
-				genesis, err := ioutil.ReadFile(config.GenesisFile())
+				genesis, err := os.ReadFile(config.GenesisFile())
 				if err != nil {
 					return err
 				}

--- a/libs/cosmos-sdk/server/mock/helpers.go
+++ b/libs/cosmos-sdk/server/mock/helpers.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	abci "github.com/okex/exchain/libs/tendermint/abci/types"
@@ -14,7 +13,7 @@ import (
 func SetupApp() (abci.Application, func(), error) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
 		With("module", "mock")
-	rootDir, err := ioutil.TempDir("", "mock-sdk")
+	rootDir, err := os.MkdirTemp("", "mock-sdk")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libs/cosmos-sdk/server/test_helpers.go
+++ b/libs/cosmos-sdk/server/test_helpers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -40,7 +39,7 @@ func FreeTCPAddr() (addr, port string, err error) {
 // SetupViper creates a homedir to run inside,
 // and returns a cleanup function to defer
 func SetupViper(t *testing.T) func() {
-	rootDir, err := ioutil.TempDir("", "mock-sdk-cmd")
+	rootDir, err := os.MkdirTemp("", "mock-sdk-cmd")
 	require.Nil(t, err)
 	viper.Set(flags.FlagHome, rootDir)
 	viper.Set(flags.FlagName, "moniker")

--- a/libs/cosmos-sdk/simapp/state.go
+++ b/libs/cosmos-sdk/simapp/state.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/okex/exchain/libs/tendermint/crypto/secp256k1"
@@ -51,7 +51,7 @@ func AppStateFn(cdc *codec.Codec, simManager *module.SimulationManager) simulati
 
 		case config.ParamsFile != "":
 			appParams := make(simulation.AppParams)
-			bz, err := ioutil.ReadFile(config.ParamsFile)
+			bz, err := os.ReadFile(config.ParamsFile)
 			if err != nil {
 				panic(err)
 			}
@@ -126,7 +126,7 @@ func AppStateRandomizedFn(
 // AppStateFromGenesisFileFn util function to generate the genesis AppState
 // from a genesis.json file.
 func AppStateFromGenesisFileFn(r io.Reader, cdc *codec.Codec, genesisFile string) (tmtypes.GenesisDoc, []simulation.Account) {
-	bytes, err := ioutil.ReadFile(genesisFile)
+	bytes, err := os.ReadFile(genesisFile)
 	if err != nil {
 		panic(err)
 	}

--- a/libs/cosmos-sdk/simapp/utils.go
+++ b/libs/cosmos-sdk/simapp/utils.go
@@ -3,7 +3,7 @@ package simapp
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	tmkv "github.com/okex/exchain/libs/tendermint/libs/kv"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
@@ -34,7 +34,7 @@ func SetupSimulation(dirPrefix, dbName string) (simulation.Config, dbm.DB, strin
 		logger = log.NewNopLogger()
 	}
 
-	dir, err := ioutil.TempDir("", dirPrefix)
+	dir, err := os.MkdirTemp("", dirPrefix)
 	if err != nil {
 		return simulation.Config{}, nil, "", nil, false, err
 	}
@@ -56,7 +56,7 @@ func SimulationOperations(app App, cdc *codec.Codec, config simulation.Config) [
 	}
 
 	if config.ParamsFile != "" {
-		bz, err := ioutil.ReadFile(config.ParamsFile)
+		bz, err := os.ReadFile(config.ParamsFile)
 		if err != nil {
 			panic(err)
 		}
@@ -81,7 +81,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportStatePath, []byte(appState), 0600); err != nil {
+		if err := os.WriteFile(config.ExportStatePath, []byte(appState), 0600); err != nil {
 			return err
 		}
 	}
@@ -93,7 +93,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportParamsPath, paramsBz, 0600); err != nil {
+		if err := os.WriteFile(config.ExportParamsPath, paramsBz, 0600); err != nil {
 			return err
 		}
 	}

--- a/libs/cosmos-sdk/tests/gobash.go
+++ b/libs/cosmos-sdk/tests/gobash.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -92,7 +91,7 @@ func GoExecuteTWithStdout(t *testing.T, cmd string) (proc *Process) {
 	// Without this, the test halts ?!
 	// (theory: because stdout and/or err aren't connected to anything the process halts)
 	go func(proc *Process) {
-		_, err := ioutil.ReadAll(proc.StdoutPipe)
+		_, err := io.ReadAll(proc.StdoutPipe)
 		if err != nil {
 			fmt.Println("-------------ERR-----------------------", err)
 			return
@@ -100,7 +99,7 @@ func GoExecuteTWithStdout(t *testing.T, cmd string) (proc *Process) {
 	}(proc)
 
 	go func(proc *Process) {
-		_, err := ioutil.ReadAll(proc.StderrPipe)
+		_, err := io.ReadAll(proc.StderrPipe)
 		if err != nil {
 			fmt.Println("-------------ERR-----------------------", err)
 			return

--- a/libs/cosmos-sdk/tests/process.go
+++ b/libs/cosmos-sdk/tests/process.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
@@ -103,13 +102,13 @@ func (proc *Process) Wait() {
 	proc.EndTime = time.Now() // TODO make this goroutine-safe
 }
 
-// ReadAll calls ioutil.ReadAll on the StdoutPipe and StderrPipe.
+// ReadAll calls io.ReadAll on the StdoutPipe and StderrPipe.
 func (proc *Process) ReadAll() (stdout []byte, stderr []byte, err error) {
-	outbz, err := ioutil.ReadAll(proc.StdoutPipe)
+	outbz, err := io.ReadAll(proc.StdoutPipe)
 	if err != nil {
 		return nil, nil, err
 	}
-	errbz, err := ioutil.ReadAll(proc.StderrPipe)
+	errbz, err := io.ReadAll(proc.StderrPipe)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libs/cosmos-sdk/tests/util.go
+++ b/libs/cosmos-sdk/tests/util.go
@@ -2,17 +2,17 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	rpchttp "github.com/okex/exchain/libs/tendermint/rpc/client/http"
 	ctypes "github.com/okex/exchain/libs/tendermint/rpc/core/types"
 	tmjsonrpc "github.com/okex/exchain/libs/tendermint/rpc/jsonrpc/client"
+	"github.com/stretchr/testify/require"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 )
@@ -112,7 +112,7 @@ func waitForHeight(height int64, url string) {
 			panic(err)
 		}
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -163,7 +163,7 @@ func WaitForStart(url string) {
 		if err != nil || res == nil {
 			continue
 		}
-		//		body, _ := ioutil.ReadAll(res.Body)
+		//		body, _ := io.ReadAll(res.Body)
 		//		fmt.Println("BODY", string(body))
 		err = res.Body.Close()
 		if err != nil {
@@ -214,7 +214,7 @@ func ExtractPortFromAddress(listenAddress string) string {
 // Returns the directory path and a cleanup function.
 // nolint: errcheck
 func NewTestCaseDir(t *testing.T) (string, func()) {
-	dir, err := ioutil.TempDir("", t.Name()+"_")
+	dir, err := os.MkdirTemp("", t.Name()+"_")
 	require.NoError(t, err)
 	return dir, func() { os.RemoveAll(dir) }
 }

--- a/libs/cosmos-sdk/types/rest/rest.go
+++ b/libs/cosmos-sdk/types/rest/rest.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -122,7 +122,7 @@ func (br BaseReq) ValidateBasic(w http.ResponseWriter) bool {
 // ReadRESTReq reads and unmarshals a Request's body to the the BaseReq stuct.
 // Writes an error response to ResponseWriter and returns true if errors occurred.
 func ReadRESTReq(w http.ResponseWriter, r *http.Request, cdc *codec.Codec, req interface{}) bool {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 		return false

--- a/libs/cosmos-sdk/types/rest/rest_test.go
+++ b/libs/cosmos-sdk/types/rest/rest_test.go
@@ -4,15 +4,14 @@ package rest
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/okex/exchain/libs/tendermint/crypto"
 	"github.com/okex/exchain/libs/tendermint/crypto/secp256k1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
@@ -213,7 +212,7 @@ func runPostProcessResponse(t *testing.T, ctx context.CLIContext, obj interface{
 	require.Equal(t, http.StatusOK, w.Code, w.Body)
 	resp := w.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.Nil(t, err)
 	require.Equal(t, expectedBody, body)
 
@@ -231,7 +230,7 @@ func runPostProcessResponse(t *testing.T, ctx context.CLIContext, obj interface{
 	require.Equal(t, http.StatusOK, w.Code, w.Body)
 	resp = w.Result()
 	defer resp.Body.Close()
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	require.Nil(t, err)
 	require.Equal(t, expectedBody, body)
 }

--- a/libs/cosmos-sdk/x/auth/client/cli/tx_multisign.go
+++ b/libs/cosmos-sdk/x/auth/client/cli/tx_multisign.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -154,7 +153,7 @@ func makeMultiSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) 
 
 func readAndUnmarshalStdSignature(cdc *codec.Codec, filename string) (stdSig types.StdSignature, err error) {
 	var bytes []byte
-	if bytes, err = ioutil.ReadFile(filename); err != nil {
+	if bytes, err = os.ReadFile(filename); err != nil {
 		return
 	}
 	if err = cdc.UnmarshalJSON(bytes, &stdSig); err != nil {

--- a/libs/cosmos-sdk/x/auth/client/rest/broadcast.go
+++ b/libs/cosmos-sdk/x/auth/client/rest/broadcast.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
@@ -22,7 +22,7 @@ func BroadcastTxRequest(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req BroadcastReq
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/libs/cosmos-sdk/x/auth/client/rest/decode.go
+++ b/libs/cosmos-sdk/x/auth/client/rest/decode.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
@@ -27,7 +27,7 @@ func DecodeTxRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req DecodeReq
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/libs/cosmos-sdk/x/auth/client/rest/encode.go
+++ b/libs/cosmos-sdk/x/auth/client/rest/encode.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
@@ -22,7 +22,7 @@ func EncodeTxRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req types.StdTx
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/libs/cosmos-sdk/x/auth/client/utils/tx.go
+++ b/libs/cosmos-sdk/x/auth/client/utils/tx.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/pkg/errors"
@@ -222,9 +222,9 @@ func ReadStdTxFromFile(cdc *codec.Codec, filename string) (stdTx authtypes.StdTx
 	var bytes []byte
 
 	if filename == "-" {
-		bytes, err = ioutil.ReadAll(os.Stdin)
+		bytes, err = io.ReadAll(os.Stdin)
 	} else {
-		bytes, err = ioutil.ReadFile(filename)
+		bytes, err = os.ReadFile(filename)
 	}
 
 	if err != nil {

--- a/libs/cosmos-sdk/x/auth/client/utils/tx_test.go
+++ b/libs/cosmos-sdk/x/auth/client/utils/tx_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -144,7 +143,7 @@ func compareEncoders(t *testing.T, expected sdk.TxEncoder, actual sdk.TxEncoder)
 }
 
 func writeToNewTempFile(t *testing.T, data string) *os.File {
-	fp, err := ioutil.TempFile(os.TempDir(), "client_tx_test")
+	fp, err := os.CreateTemp(os.TempDir(), "client_tx_test")
 	require.NoError(t, err)
 
 	_, err = fp.WriteString(data)

--- a/libs/cosmos-sdk/x/distribution/client/cli/utils.go
+++ b/libs/cosmos-sdk/x/distribution/client/cli/utils.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -22,7 +22,7 @@ type (
 func ParseCommunityPoolSpendProposalJSON(cdc *codec.Codec, proposalFile string) (CommunityPoolSpendProposalJSON, error) {
 	proposal := CommunityPoolSpendProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/libs/cosmos-sdk/x/genutil/client/cli/gentx.go
+++ b/libs/cosmos-sdk/x/genutil/client/cli/gentx.go
@@ -6,18 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	cfg "github.com/okex/exchain/libs/tendermint/config"
 	"github.com/okex/exchain/libs/tendermint/crypto"
 	tmos "github.com/okex/exchain/libs/tendermint/libs/os"
 	tmtypes "github.com/okex/exchain/libs/tendermint/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
 	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
@@ -204,7 +203,7 @@ func makeOutputFilepath(rootDir, nodeID string) (string, error) {
 
 func readUnsignedGenTxFile(cdc *codec.Codec, r io.Reader) (auth.StdTx, error) {
 	var stdTx auth.StdTx
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return stdTx, err
 	}

--- a/libs/cosmos-sdk/x/genutil/client/cli/migrate_test.go
+++ b/libs/cosmos-sdk/x/genutil/client/cli/migrate_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,12 +14,12 @@ import (
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	genutilcli "github.com/okex/exchain/libs/cosmos-sdk/x/genutil/client/cli"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 	tcmd "github.com/okex/exchain/libs/tendermint/cmd/tendermint/commands"
 	"github.com/okex/exchain/libs/tendermint/libs/cli"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
 	"github.com/okex/exchain/libs/cosmos-sdk/server"
@@ -74,7 +73,7 @@ func TestMigrateGenesis(t *testing.T) {
 
 	// Noop migration with minimal genesis
 	emptyGenesis := []byte(`{"chain_id":"test","app_state":{}}`)
-	err = ioutil.WriteFile(genesisPath, emptyGenesis, 0600)
+	err = os.WriteFile(genesisPath, emptyGenesis, 0600)
 	require.Nil(t, err)
 	cmd := setupCmd("", "test2")
 	require.NoError(t, genutilcli.MigrateGenesisCmd(ctx, cdc).RunE(cmd, []string{target, genesisPath}))

--- a/libs/cosmos-sdk/x/genutil/collect.go
+++ b/libs/cosmos-sdk/x/genutil/collect.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -70,8 +69,7 @@ func CollectStdTxs(cdc *codec.Codec, moniker, genTxsDir string,
 	genDoc tmtypes.GenesisDoc, genAccIterator types.GenesisAccountsIterator,
 ) (appGenTxs []authtypes.StdTx, persistentPeers string, err error) {
 
-	var fos []os.FileInfo
-	fos, err = ioutil.ReadDir(genTxsDir)
+	fos, err := os.ReadDir(genTxsDir)
 	if err != nil {
 		return appGenTxs, persistentPeers, err
 	}
@@ -102,7 +100,7 @@ func CollectStdTxs(cdc *codec.Codec, moniker, genTxsDir string,
 
 		// get the genStdTx
 		var jsonRawTx []byte
-		if jsonRawTx, err = ioutil.ReadFile(filename); err != nil {
+		if jsonRawTx, err = os.ReadFile(filename); err != nil {
 			return appGenTxs, persistentPeers, err
 		}
 		var genStdTx authtypes.StdTx

--- a/libs/cosmos-sdk/x/gov/client/cli/parse.go
+++ b/libs/cosmos-sdk/x/gov/client/cli/parse.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/viper"
 
@@ -28,7 +28,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		}
 	}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/cosmos-sdk/x/gov/client/cli/parse_test.go
+++ b/libs/cosmos-sdk/x/gov/client/cli/parse_test.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParseSubmitProposalFlags(t *testing.T) {
-	okJSON, err := ioutil.TempFile("", "proposal")
+	okJSON, err := os.CreateTemp("", "proposal")
 	require.Nil(t, err, "unexpected error")
 	okJSON.WriteString(`
 {
@@ -20,7 +20,7 @@ func TestParseSubmitProposalFlags(t *testing.T) {
 }
 `)
 
-	badJSON, err := ioutil.TempFile("", "proposal")
+	badJSON, err := os.CreateTemp("", "proposal")
 	require.Nil(t, err, "unexpected error")
 	badJSON.WriteString("bad json")
 

--- a/libs/cosmos-sdk/x/params/client/utils/utils.go
+++ b/libs/cosmos-sdk/x/params/client/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -68,7 +68,7 @@ func (pcj ParamChangesJSON) ToParamChanges() []params.ParamChange {
 func ParseParamChangeProposalJSON(cdc *codec.Codec, proposalFile string) (ParamChangeProposalJSON, error) {
 	proposal := ParamChangeProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/libs/cosmos-sdk/x/simulation/event_stats.go
+++ b/libs/cosmos-sdk/x/simulation/event_stats.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // EventStats defines an object that keeps a tally of each event that has occurred
@@ -48,7 +48,7 @@ func (es EventStats) ExportJSON(path string) {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(path, bz, 0600)
+	err = os.WriteFile(path, bz, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/libs/iavl/benchmarks/cosmos-exim/main.go
+++ b/libs/iavl/benchmarks/cosmos-exim/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -155,7 +154,7 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 	totalStats := Stats{}
 
 	for _, name := range stores {
-		tempdir, err := ioutil.TempDir("", name)
+		tempdir, err := os.MkdirTemp("", name)
 		if err != nil {
 			return err
 		}

--- a/libs/iavl/repair_test.go
+++ b/libs/iavl/repair_test.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestRepair013Orphans(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-iavl-repair")
+	dir, err := os.MkdirTemp("", "test-iavl-repair")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -161,7 +160,7 @@ func assertVersion(t *testing.T, tree *MutableTree, version int64) {
 
 // copyDB makes a shallow copy of the source database directory.
 func copyDB(src, dest string) error {
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}

--- a/libs/iavl/tree_dotgraph_test.go
+++ b/libs/iavl/tree_dotgraph_test.go
@@ -1,7 +1,7 @@
 package iavl
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,5 +16,5 @@ func TestWriteDOTGraph(t *testing.T) {
 		key := []byte{ikey}
 		tree.Set(key, key)
 	}
-	WriteDOTGraph(ioutil.Discard, tree.ImmutableTree, []PathToLeaf{})
+	WriteDOTGraph(io.Discard, tree.ImmutableTree, []PathToLeaf{})
 }

--- a/libs/iavl/tree_random_test.go
+++ b/libs/iavl/tree_random_test.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sort"
@@ -96,7 +95,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 	}
 
 	// Use the same on-disk database for the entire run.
-	tempdir, err := ioutil.TempDir("", "iavl")
+	tempdir, err := os.MkdirTemp("", "iavl")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempdir)
 

--- a/libs/tendermint/abci/example/kvstore/kvstore_test.go
+++ b/libs/tendermint/abci/example/kvstore/kvstore_test.go
@@ -3,7 +3,7 @@ package kvstore
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -71,7 +71,7 @@ func TestKVStoreKV(t *testing.T) {
 }
 
 func TestPersistentKVStoreKV(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
+	dir, err := os.MkdirTemp("/tmp", "abci-kvstore-test") // TODO
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestPersistentKVStoreKV(t *testing.T) {
 }
 
 func TestPersistentKVStoreInfo(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
+	dir, err := os.MkdirTemp("/tmp", "abci-kvstore-test") // TODO
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestPersistentKVStoreInfo(t *testing.T) {
 
 // add a validator, remove a validator, update a validator
 func TestValUpdates(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
+	dir, err := os.MkdirTemp("/tmp", "abci-kvstore-test") // TODO
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libs/tendermint/abci/types/protoreplace/protoreplace.go
+++ b/libs/tendermint/abci/types/protoreplace/protoreplace.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main
@@ -5,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -21,7 +21,7 @@ func main() {
 	bytePattern := regexp.MustCompile("[[][]]byte")
 	const oldPath = "types/types.pb.go"
 	const tmpPath = "types/types.pb.new"
-	content, err := ioutil.ReadFile(oldPath)
+	content, err := os.ReadFile(oldPath)
 	if err != nil {
 		panic("cannot read " + oldPath)
 		os.Exit(1)

--- a/libs/tendermint/cmd/tendermint/commands/debug/dump.go
+++ b/libs/tendermint/cmd/tendermint/commands/debug/dump.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -82,7 +81,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 func dumpDebugData(outDir string, conf *cfg.Config, rpc *rpchttp.HTTP) {
 	start := time.Now().UTC()
 
-	tmpDir, err := ioutil.TempDir(outDir, "tendermint_debug_tmp")
+	tmpDir, err := os.MkdirTemp(outDir, "tendermint_debug_tmp")
 	if err != nil {
 		logger.Error("failed to create temporary directory", "dir", tmpDir, "error", err)
 		return

--- a/libs/tendermint/cmd/tendermint/commands/debug/io.go
+++ b/libs/tendermint/cmd/tendermint/commands/debug/io.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -113,5 +112,5 @@ func writeStateJSONToFile(state interface{}, dir, filename string) error {
 		return errors.Wrap(err, "failed to encode state dump")
 	}
 
-	return ioutil.WriteFile(path.Join(dir, filename), stateJSON, os.ModePerm)
+	return os.WriteFile(path.Join(dir, filename), stateJSON, os.ModePerm)
 }

--- a/libs/tendermint/cmd/tendermint/commands/debug/kill.go
+++ b/libs/tendermint/cmd/tendermint/commands/debug/kill.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 
 	// Create a temporary directory which will contain all the state dumps and
 	// relevant files and directories that will be compressed into a file.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "tendermint_debug_tmp")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "tendermint_debug_tmp")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temporary directory")
 	}

--- a/libs/tendermint/cmd/tendermint/commands/debug/util.go
+++ b/libs/tendermint/cmd/tendermint/commands/debug/util.go
@@ -2,7 +2,7 @@ package debug
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -74,10 +74,10 @@ func dumpProfile(dir, addr, profile string, debug int) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %s profile response body", profile)
 	}
 
-	return ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%s.out", profile)), body, os.ModePerm)
+	return os.WriteFile(path.Join(dir, fmt.Sprintf("%s.out", profile)), body, os.ModePerm)
 }

--- a/libs/tendermint/cmd/tendermint/commands/root_test.go
+++ b/libs/tendermint/cmd/tendermint/commands/root_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -168,5 +167,5 @@ func WriteConfigVals(dir string, vals map[string]string) error {
 		data += fmt.Sprintf("%s = \"%s\"\n", k, v)
 	}
 	cfile := filepath.Join(dir, "config.toml")
-	return ioutil.WriteFile(cfile, []byte(data), 0666)
+	return os.WriteFile(cfile, []byte(data), 0666)
 }

--- a/libs/tendermint/config/toml.go
+++ b/libs/tendermint/config/toml.go
@@ -3,7 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"text/template"
 
@@ -429,7 +429,7 @@ func ResetTestRoot(testName string) *Config {
 
 func ResetTestRootWithChainID(testName string, chainID string) *Config {
 	// create a unique, concurrency-safe test directory under os.TempDir()
-	rootDir, err := ioutil.TempDir("", fmt.Sprintf("%s-%s_", chainID, testName))
+	rootDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%s_", chainID, testName))
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/config/toml_test.go
+++ b/libs/tendermint/config/toml_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +22,7 @@ func TestEnsureRoot(t *testing.T) {
 	require := require.New(t)
 
 	// setup temp dir for test
-	tmpDir, err := ioutil.TempDir("", "config-test")
+	tmpDir, err := os.MkdirTemp("", "config-test")
 	require.Nil(err)
 	defer os.RemoveAll(tmpDir) // nolint: errcheck
 
@@ -31,7 +30,7 @@ func TestEnsureRoot(t *testing.T) {
 	EnsureRoot(tmpDir)
 
 	// make sure config is set properly
-	data, err := ioutil.ReadFile(filepath.Join(tmpDir, defaultConfigFilePath))
+	data, err := os.ReadFile(filepath.Join(tmpDir, defaultConfigFilePath))
 	require.Nil(err)
 
 	if !checkConfig(string(data)) {
@@ -52,7 +51,7 @@ func TestEnsureTestRoot(t *testing.T) {
 	rootDir := cfg.RootDir
 
 	// make sure config is set properly
-	data, err := ioutil.ReadFile(filepath.Join(rootDir, defaultConfigFilePath))
+	data, err := os.ReadFile(filepath.Join(rootDir, defaultConfigFilePath))
 	require.Nil(err)
 
 	if !checkConfig(string(data)) {

--- a/libs/tendermint/consensus/common_test.go
+++ b/libs/tendermint/consensus/common_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -740,11 +739,11 @@ func randConsensusNetWithPeers(
 		if i < nValidators {
 			privVal = privVals[i]
 		} else {
-			tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+			tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 			if err != nil {
 				panic(err)
 			}
-			tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+			tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 			if err != nil {
 				panic(err)
 			}
@@ -871,7 +870,7 @@ func newCounter() abci.Application {
 }
 
 func newPersistentKVStore() abci.Application {
-	dir, err := ioutil.TempDir("", "persistent-kvstore")
+	dir, err := os.MkdirTemp("", "persistent-kvstore")
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/consensus/replay_test.go
+++ b/libs/tendermint/consensus/replay_test.go
@@ -5,17 +5,15 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"sort"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -80,7 +78,7 @@ func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Confi
 	)
 	cs.SetLogger(logger)
 
-	bytes, _ := ioutil.ReadFile(cs.config.WalFile())
+	bytes, _ := os.ReadFile(cs.config.WalFile())
 	t.Logf("====== WAL: \n\r%X\n", bytes)
 
 	err := cs.Start()
@@ -627,7 +625,7 @@ func TestMockProxyApp(t *testing.T) {
 }
 
 func tempWALWithData(data []byte) string {
-	walFile, err := ioutil.TempFile("", "wal")
+	walFile, err := os.CreateTemp("", "wal")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp WAL file: %v", err))
 	}

--- a/libs/tendermint/consensus/wal_test.go
+++ b/libs/tendermint/consensus/wal_test.go
@@ -3,10 +3,8 @@ package consensus
 import (
 	"bytes"
 	"crypto/rand"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-
 	// "sync"
 	"testing"
 	"time"
@@ -29,9 +27,7 @@ const (
 func TestWALTruncate(t *testing.T) {
 	//need to fix wal nil
 	return
-	walDir, err := ioutil.TempDir("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 
@@ -107,9 +103,7 @@ func TestWALEncoderDecoder(t *testing.T) {
 }
 
 func TestWALWrite(t *testing.T) {
-	walDir, err := ioutil.TempDir("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 	walFile := filepath.Join(walDir, "wal")
 
 	wal, err := NewWAL(walFile)
@@ -174,9 +168,7 @@ func TestWALSearchForEndHeight(t *testing.T) {
 func TestWALPeriodicSync(t *testing.T) {
 	//need to fix wal nil
 	return
-	walDir, err := ioutil.TempDir("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 	wal, err := NewWAL(walFile, autofile.GroupCheckDuration(1*time.Millisecond))

--- a/libs/tendermint/crypto/armor/armor.go
+++ b/libs/tendermint/crypto/armor/armor.go
@@ -3,7 +3,7 @@ package armor
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"golang.org/x/crypto/openpgp/armor"
 )
@@ -31,7 +31,7 @@ func DecodeArmor(armorStr string) (blockType string, headers map[string]string, 
 	if err != nil {
 		return "", nil, nil, err
 	}
-	data, err = ioutil.ReadAll(block.Body)
+	data, err = io.ReadAll(block.Body)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/libs/tendermint/libs/autofile/autofile_test.go
+++ b/libs/tendermint/libs/autofile/autofile_test.go
@@ -1,7 +1,6 @@
 package autofile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -20,7 +19,7 @@ func TestSIGHUP(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// First, create a temporary directory and move into it
-	dir, err := ioutil.TempDir("", "sighup_test")
+	dir, err := os.MkdirTemp("", "sighup_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	err = os.Chdir(dir)
@@ -43,7 +42,7 @@ func TestSIGHUP(t *testing.T) {
 	require.NoError(t, err)
 
 	// Move into a different temporary directory
-	otherDir, err := ioutil.TempDir("", "sighup_test_other")
+	otherDir, err := os.MkdirTemp("", "sighup_test_other")
 	require.NoError(t, err)
 	defer os.RemoveAll(otherDir)
 	err = os.Chdir(otherDir)
@@ -72,7 +71,7 @@ func TestSIGHUP(t *testing.T) {
 	}
 
 	// The current directory should be empty
-	files, err := ioutil.ReadDir(".")
+	files, err := os.ReadDir(".")
 	require.NoError(t, err)
 	assert.Empty(t, files)
 }
@@ -80,7 +79,7 @@ func TestSIGHUP(t *testing.T) {
 // // Manually modify file permissions, close, and reopen using autofile:
 // // We expect the file permissions to be changed back to the intended perms.
 // func TestOpenAutoFilePerms(t *testing.T) {
-// 	file, err := ioutil.TempFile("", "permission_test")
+// 	file, err := os.CreateTemp("", "permission_test")
 // 	require.NoError(t, err)
 // 	err = file.Close()
 // 	require.NoError(t, err)
@@ -106,7 +105,7 @@ func TestSIGHUP(t *testing.T) {
 
 func TestAutoFileSize(t *testing.T) {
 	// First, create an AutoFile writing to a tempfile dir
-	f, err := ioutil.TempFile("", "sighup_test")
+	f, err := os.CreateTemp("", "sighup_test")
 	require.NoError(t, err)
 	err = f.Close()
 	require.NoError(t, err)

--- a/libs/tendermint/libs/autofile/group_test.go
+++ b/libs/tendermint/libs/autofile/group_test.go
@@ -2,7 +2,6 @@ package autofile
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,7 +112,7 @@ func TestRotateFile(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Chdir(origDir)
 
-	dir, err := ioutil.TempDir("", "rotate_test")
+	dir, err := os.MkdirTemp("", "rotate_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	err = os.Chdir(dir)
@@ -134,21 +133,21 @@ func TestRotateFile(t *testing.T) {
 	g.FlushAndSync()
 
 	// Read g.Head.Path+"000"
-	body1, err := ioutil.ReadFile(g.Head.Path + ".000")
+	body1, err := os.ReadFile(g.Head.Path + ".000")
 	assert.NoError(t, err, "Failed to read first rolled file")
 	if string(body1) != "Line 1\nLine 2\nLine 3\n" {
 		t.Errorf("got unexpected contents: [%v]", string(body1))
 	}
 
 	// Read g.Head.Path
-	body2, err := ioutil.ReadFile(g.Head.Path)
+	body2, err := os.ReadFile(g.Head.Path)
 	assert.NoError(t, err, "Failed to read first rolled file")
 	if string(body2) != "Line 4\nLine 5\nLine 6\n" {
 		t.Errorf("got unexpected contents: [%v]", string(body2))
 	}
 
 	// Make sure there are no files in the current, temporary directory
-	files, err := ioutil.ReadDir(".")
+	files, err := os.ReadDir(".")
 	require.NoError(t, err)
 	assert.Empty(t, files)
 

--- a/libs/tendermint/libs/automation/automation.go
+++ b/libs/tendermint/libs/automation/automation.go
@@ -3,11 +3,12 @@ package automation
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/okex/exchain/libs/tendermint/libs/log"
-	"github.com/spf13/viper"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
+
+	"github.com/okex/exchain/libs/tendermint/libs/log"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -59,7 +60,8 @@ func LoadTestCase(log log.Logger) {
 
 	tlog = log
 
-	content, err := ioutil.ReadFile(confFilePath)
+	content, err := os.ReadFile(confFilePath)
+
 	if err != nil {
 		panic(fmt.Sprintf("read file : %s fail err : %s", confFilePath, err))
 	}

--- a/libs/tendermint/libs/cli/helper.go
+++ b/libs/tendermint/libs/cli/helper.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -19,7 +18,7 @@ func WriteConfigVals(dir string, vals map[string]string) error {
 		data += fmt.Sprintf("%s = \"%s\"\n", k, v)
 	}
 	cfile := filepath.Join(dir, "config.toml")
-	return ioutil.WriteFile(cfile, []byte(data), 0666)
+	return os.WriteFile(cfile, []byte(data), 0666)
 }
 
 // RunWithArgs executes the given command with the specified command line args

--- a/libs/tendermint/libs/cli/setup_test.go
+++ b/libs/tendermint/libs/cli/setup_test.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -56,7 +56,7 @@ func TestSetupEnv(t *testing.T) {
 }
 
 func tempDir() string {
-	cdir, err := ioutil.TempDir("", "test-cli")
+	cdir, err := os.MkdirTemp("", "test-cli")
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/libs/log/tm_logger_test.go
+++ b/libs/tendermint/libs/log/tm_logger_test.go
@@ -2,7 +2,7 @@ package log_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -21,11 +21,11 @@ func TestLoggerLogsItsErrors(t *testing.T) {
 }
 
 func BenchmarkTMLoggerSimple(b *testing.B) {
-	benchmarkRunner(b, log.NewTMLogger(ioutil.Discard), baseInfoMessage)
+	benchmarkRunner(b, log.NewTMLogger(io.Discard), baseInfoMessage)
 }
 
 func BenchmarkTMLoggerContextual(b *testing.B) {
-	benchmarkRunner(b, log.NewTMLogger(ioutil.Discard), withInfoMessage)
+	benchmarkRunner(b, log.NewTMLogger(io.Discard), withInfoMessage)
 }
 
 func benchmarkRunner(b *testing.B, logger log.Logger, f func(log.Logger)) {

--- a/libs/tendermint/libs/log/tmfmt_logger_test.go
+++ b/libs/tendermint/libs/log/tmfmt_logger_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math"
 	"regexp"
 	"testing"
@@ -56,16 +56,16 @@ func TestTMFmtLogger(t *testing.T) {
 }
 
 func BenchmarkTMFmtLoggerSimple(b *testing.B) {
-	benchmarkRunnerKitlog(b, log.NewTMFmtLogger(ioutil.Discard), baseMessage)
+	benchmarkRunnerKitlog(b, log.NewTMFmtLogger(io.Discard), baseMessage)
 }
 
 func BenchmarkTMFmtLoggerContextual(b *testing.B) {
-	benchmarkRunnerKitlog(b, log.NewTMFmtLogger(ioutil.Discard), withMessage)
+	benchmarkRunnerKitlog(b, log.NewTMFmtLogger(io.Discard), withMessage)
 }
 
 func TestTMFmtLoggerConcurrency(t *testing.T) {
 	t.Parallel()
-	testConcurrency(t, log.NewTMFmtLogger(ioutil.Discard), 10000)
+	testConcurrency(t, log.NewTMFmtLogger(io.Discard), 10000)
 }
 
 func benchmarkRunnerKitlog(b *testing.B, logger kitlog.Logger, f func(kitlog.Logger)) {

--- a/libs/tendermint/libs/os/os.go
+++ b/libs/tendermint/libs/os/os.go
@@ -2,7 +2,6 @@ package os
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -58,11 +57,11 @@ func FileExists(filePath string) bool {
 }
 
 func ReadFile(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 func MustReadFile(filePath string) []byte {
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		Exit(fmt.Sprintf("MustReadFile failed: %v", err))
 		return nil
@@ -71,7 +70,7 @@ func MustReadFile(filePath string) []byte {
 }
 
 func WriteFile(filePath string, contents []byte, mode os.FileMode) error {
-	return ioutil.WriteFile(filePath, contents, mode)
+	return os.WriteFile(filePath, contents, mode)
 }
 
 func MustWriteFile(filePath string, contents []byte, mode os.FileMode) {

--- a/libs/tendermint/libs/tempfile/tempfile_test.go
+++ b/libs/tendermint/libs/tempfile/tempfile_test.go
@@ -5,7 +5,6 @@ package tempfile
 import (
 	"bytes"
 	fmt "fmt"
-	"io/ioutil"
 	"os"
 	testing "testing"
 
@@ -21,13 +20,13 @@ func TestWriteFileAtomic(t *testing.T) {
 		perm os.FileMode = 0600
 	)
 
-	f, err := ioutil.TempFile("/tmp", "write-atomic-test-")
+	f, err := os.CreateTemp("/tmp", "write-atomic-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(f.Name())
 
-	if err = ioutil.WriteFile(f.Name(), old, 0664); err != nil {
+	if err = os.WriteFile(f.Name(), old, 0664); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +34,7 @@ func TestWriteFileAtomic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rData, err := ioutil.ReadFile(f.Name())
+	rData, err := os.ReadFile(f.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,11 +77,11 @@ func TestWriteFileAtomicDuplicateFile(t *testing.T) {
 	f.WriteString(testString)
 	WriteFileAtomic(fileToWrite, []byte(expectedString), 0777)
 	// Check that the first atomic file was untouched
-	firstAtomicFileBytes, err := ioutil.ReadFile(fname)
+	firstAtomicFileBytes, err := os.ReadFile(fname)
 	require.Nil(t, err, "Error reading first atomic file")
 	require.Equal(t, []byte(testString), firstAtomicFileBytes, "First atomic file was overwritten")
 	// Check that the resultant file is correct
-	resultantFileBytes, err := ioutil.ReadFile(fileToWrite)
+	resultantFileBytes, err := os.ReadFile(fileToWrite)
 	require.Nil(t, err, "Error reading resultant file")
 	require.Equal(t, []byte(expectedString), resultantFileBytes, "Written file had incorrect bytes")
 
@@ -127,14 +126,14 @@ func TestWriteFileAtomicManyDuplicates(t *testing.T) {
 	for i := 0; i < atomicWriteFileMaxNumConflicts+2; i++ {
 		fileRand := randWriteFileSuffix()
 		fname := "/tmp/" + atomicWriteFilePrefix + fileRand
-		firstAtomicFileBytes, err := ioutil.ReadFile(fname)
+		firstAtomicFileBytes, err := os.ReadFile(fname)
 		require.Nil(t, err, "Error reading first atomic file")
 		require.Equal(t, []byte(fmt.Sprintf(testString, i)), firstAtomicFileBytes,
 			"atomic write file %d was overwritten", i)
 	}
 
 	// Check that the resultant file is correct
-	resultantFileBytes, err := ioutil.ReadFile(fileToWrite)
+	resultantFileBytes, err := os.ReadFile(fileToWrite)
 	require.Nil(t, err, "Error reading resultant file")
 	require.Equal(t, []byte(expectedString), resultantFileBytes, "Written file had incorrect bytes")
 }

--- a/libs/tendermint/lite2/example_test.go
+++ b/libs/tendermint/lite2/example_test.go
@@ -2,7 +2,6 @@ package lite_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"os"
 	"testing"
@@ -23,7 +22,7 @@ func ExampleClient_Update() {
 	// give Tendermint time to generate some blocks
 	time.Sleep(5 * time.Second)
 
-	dbDir, err := ioutil.TempDir("", "lite-client-example")
+	dbDir, err := os.MkdirTemp("", "lite-client-example")
 	if err != nil {
 		stdlog.Fatal(err)
 	}
@@ -92,7 +91,7 @@ func ExampleClient_VerifyHeaderAtHeight() {
 	// give Tendermint time to generate some blocks
 	time.Sleep(5 * time.Second)
 
-	dbDir, err := ioutil.TempDir("", "lite-client-example")
+	dbDir, err := os.MkdirTemp("", "lite-client-example")
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/libs/tendermint/mempool/clist_mempool_test.go
+++ b/libs/tendermint/mempool/clist_mempool_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	mrand "math/rand"
 	"os"
@@ -381,7 +380,7 @@ func TestSerialReap(t *testing.T) {
 
 func TestMempoolCloseWAL(t *testing.T) {
 	// 1. Create the temporary directory for mempool and WAL testing.
-	rootDir, err := ioutil.TempDir("", "mempool-test")
+	rootDir, err := os.MkdirTemp("", "mempool-test")
 	require.Nil(t, err, "expecting successful tmpdir creation")
 
 	// 2. Ensure that it doesn't contain any elements -- Sanity check
@@ -617,7 +616,7 @@ func checksumIt(data []byte) string {
 }
 
 func checksumFile(p string, t *testing.T) string {
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	require.Nil(t, err, "expecting successful read of %q", p)
 	return checksumIt(data)
 }

--- a/libs/tendermint/networks/remote/integration.sh
+++ b/libs/tendermint/networks/remote/integration.sh
@@ -10,8 +10,8 @@ sudo apt-get upgrade -y
 sudo apt-get install -y jq unzip python-pip software-properties-common make
 
 # get and unpack golang
-curl -O https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz
-tar -xvf go1.13.linux-amd64.tar.gz
+curl -O https://storage.googleapis.com/golang/go1.17.linux-amd64.tar.gz
+tar -xvf go1.17.linux-amd64.tar.gz
 
 ## move binary and add to path
 mv go /usr/local

--- a/libs/tendermint/p2p/key.go
+++ b/libs/tendermint/p2p/key.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/tendermint/crypto"
 	"github.com/okex/exchain/libs/tendermint/crypto/ed25519"
@@ -58,7 +58,7 @@ func LoadOrGenNodeKey(filePath string) (*NodeKey, error) {
 }
 
 func LoadNodeKey(filePath string) (*NodeKey, error) {
-	jsonBytes, err := ioutil.ReadFile(filePath)
+	jsonBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func genNodeKey(filePath string) (*NodeKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = ioutil.WriteFile(filePath, jsonBytes, 0600)
+	err = os.WriteFile(filePath, jsonBytes, 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/tendermint/p2p/pex/addrbook_test.go
+++ b/libs/tendermint/p2p/pex/addrbook_test.go
@@ -3,7 +3,6 @@ package pex
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -647,7 +646,7 @@ func assertMOldAndNNewAddrsInSelection(t *testing.T, m, n int, addrs []*p2p.NetA
 }
 
 func createTempFileName(prefix string) string {
-	f, err := ioutil.TempFile("", prefix)
+	f, err := os.CreateTemp("", prefix)
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/p2p/pex/pex_reactor_test.go
+++ b/libs/tendermint/p2p/pex/pex_reactor_test.go
@@ -2,7 +2,6 @@ package pex
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,7 +69,7 @@ func TestPEXReactorRunning(t *testing.T) {
 	switches := make([]*p2p.Switch, N)
 
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -204,7 +203,7 @@ func TestPEXReactorAddrsMessageAbuse(t *testing.T) {
 
 func TestCheckSeeds(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -243,7 +242,7 @@ func TestCheckSeeds(t *testing.T) {
 
 func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -263,7 +262,7 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 
 func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -292,7 +291,7 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 
 func TestPEXReactorSeedMode(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -331,7 +330,7 @@ func TestPEXReactorSeedMode(t *testing.T) {
 
 func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -369,7 +368,7 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 
 func TestPEXReactorDialsPeerUpToMaxAttemptsInSeedMode(t *testing.T) {
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -405,7 +404,7 @@ func TestPEXReactorSeedModeFlushStop(t *testing.T) {
 	switches := make([]*p2p.Switch, N)
 
 	// directory to store address books
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
@@ -638,7 +637,7 @@ func testCreatePeerWithSeed(dir string, id int, seed *p2p.Switch) *p2p.Switch {
 
 func createReactor(conf *ReactorConfig) (r *Reactor, book AddrBook) {
 	// directory to store address book
-	dir, err := ioutil.TempDir("", "pex_reactor")
+	dir, err := os.MkdirTemp("", "pex_reactor")
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/p2p/switch_test.go
+++ b/libs/tendermint/p2p/switch_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -371,7 +370,7 @@ func TestSwitchStopPeerForError(t *testing.T) {
 		resp, err := http.Get(s.URL)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		buf, _ := ioutil.ReadAll(resp.Body)
+		buf, _ := io.ReadAll(resp.Body)
 		return string(buf)
 	}
 

--- a/libs/tendermint/p2p/trust/store_test.go
+++ b/libs/tendermint/p2p/trust/store_test.go
@@ -5,7 +5,6 @@ package trust
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 )
 
 func TestTrustMetricStoreSaveLoad(t *testing.T) {
-	dir, err := ioutil.TempDir("", "trust_test")
+	dir, err := os.MkdirTemp("", "trust_test")
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/p2p/upnp/upnp.go
+++ b/libs/tendermint/p2p/upnp/upnp.go
@@ -10,7 +10,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -312,7 +312,7 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 		return
 	}
 	var envelope Envelope
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return
 	}
@@ -374,7 +374,7 @@ func (n *upnpNAT) AddPortMapping(
 	// TODO: check response to see if the port was forwarded
 	// log.Println(message, response)
 	// JAE:
-	// body, err := ioutil.ReadAll(response.Body)
+	// body, err := io.ReadAll(response.Body)
 	// fmt.Println(string(body), err)
 	mappedExternalPort = externalPort
 	_ = response

--- a/libs/tendermint/privval/file.go
+++ b/libs/tendermint/privval/file.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/okex/exchain/libs/tendermint/crypto"
@@ -181,7 +181,7 @@ func LoadFilePVEmptyState(keyFilePath, stateFilePath string) *FilePV {
 
 // If loadState is true, we load from the stateFilePath. Otherwise, we use an empty LastSignState.
 func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
-	keyJSONBytes, err := ioutil.ReadFile(keyFilePath)
+	keyJSONBytes, err := os.ReadFile(keyFilePath)
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
@@ -198,7 +198,7 @@ func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
 
 	pvState := FilePVLastSignState{}
 	if loadState {
-		stateJSONBytes, err := ioutil.ReadFile(stateFilePath)
+		stateJSONBytes, err := os.ReadFile(stateFilePath)
 		if err != nil {
 			tmos.Exit(err.Error())
 		}

--- a/libs/tendermint/privval/file_test.go
+++ b/libs/tendermint/privval/file_test.go
@@ -3,7 +3,6 @@ package privval
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -19,9 +18,9 @@ import (
 func TestGenLoadValidator(t *testing.T) {
 	assert := assert.New(t)
 
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	privVal := GenFilePV(tempKeyFile.Name(), tempStateFile.Name())
@@ -37,9 +36,9 @@ func TestGenLoadValidator(t *testing.T) {
 }
 
 func TestResetValidator(t *testing.T) {
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	privVal := GenFilePV(tempKeyFile.Name(), tempStateFile.Name())
@@ -67,9 +66,9 @@ func TestResetValidator(t *testing.T) {
 func TestLoadOrGenValidator(t *testing.T) {
 	assert := assert.New(t)
 
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	tempKeyFilePath := tempKeyFile.Name()
@@ -156,9 +155,9 @@ func TestUnmarshalValidatorKey(t *testing.T) {
 func TestSignVote(t *testing.T) {
 	assert := assert.New(t)
 
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	privVal := GenFilePV(tempKeyFile.Name(), tempStateFile.Name())
@@ -202,9 +201,9 @@ func TestSignVote(t *testing.T) {
 func TestSignProposal(t *testing.T) {
 	assert := assert.New(t)
 
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	privVal := GenFilePV(tempKeyFile.Name(), tempStateFile.Name())
@@ -244,9 +243,9 @@ func TestSignProposal(t *testing.T) {
 }
 
 func TestDifferByTimestamp(t *testing.T) {
-	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	tempKeyFile, err := os.CreateTemp("", "priv_validator_key_")
 	require.Nil(t, err)
-	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	tempStateFile, err := os.CreateTemp("", "priv_validator_state_")
 	require.Nil(t, err)
 
 	privVal := GenFilePV(tempKeyFile.Name(), tempStateFile.Name())

--- a/libs/tendermint/privval/socket_listeners_test.go
+++ b/libs/tendermint/privval/socket_listeners_test.go
@@ -1,7 +1,6 @@
 package privval
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -29,7 +28,7 @@ type listenerTestCase struct {
 // testUnixAddr will attempt to obtain a platform-independent temporary file
 // name for a Unix socket
 func testUnixAddr() (string, error) {
-	f, err := ioutil.TempFile("", "tendermint-privval-test-*")
+	f, err := os.CreateTemp("", "tendermint-privval-test-*")
 	if err != nil {
 		return "", err
 	}

--- a/libs/tendermint/rpc/client/main_test.go
+++ b/libs/tendermint/rpc/client/main_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,7 +13,7 @@ var node *nm.Node
 
 func TestMain(m *testing.M) {
 	// start a tendermint node (and kvstore) in the background to test against
-	dir, err := ioutil.TempDir("/tmp", "rpc-client-test")
+	dir, err := os.MkdirTemp("/tmp", "rpc-client-test")
 	if err != nil {
 		panic(err)
 	}

--- a/libs/tendermint/rpc/jsonrpc/client/http_json_client.go
+++ b/libs/tendermint/rpc/jsonrpc/client/http_json_client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -191,7 +191,7 @@ func (c *Client) Call(method string, params map[string]interface{}, result inter
 	}
 	defer httpResponse.Body.Close() // nolint: errcheck
 
-	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
+	responseBytes, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
@@ -238,7 +238,7 @@ func (c *Client) sendBatch(requests []*jsonRPCBufferedRequest) ([]interface{}, e
 	}
 	defer httpResponse.Body.Close() // nolint: errcheck
 
-	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
+	responseBytes, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/libs/tendermint/rpc/jsonrpc/client/http_uri_client.go
+++ b/libs/tendermint/rpc/jsonrpc/client/http_uri_client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -69,7 +69,7 @@ func (c *URIClient) Call(method string, params map[string]interface{}, result in
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
-	responseBytes, err := ioutil.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/libs/tendermint/rpc/jsonrpc/server/http_json_handler.go
+++ b/libs/tendermint/rpc/jsonrpc/server/http_json_handler.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -24,7 +24,7 @@ import (
 // jsonrpc calls grab the given method's function info and runs reflect.Call
 func makeJSONRPCHandler(funcMap map[string]*RPCFunc, cdc *amino.Codec, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			WriteRPCResponseHTTP(
 				w,

--- a/libs/tendermint/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/libs/tendermint/rpc/jsonrpc/server/http_json_handler_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,7 +69,7 @@ func TestRPCParams(t *testing.T) {
 		defer res.Body.Close()
 		// Always expecting back a JSONRPCResponse
 		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
-		blob, err := ioutil.ReadAll(res.Body)
+		blob, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Errorf("#%d: err reading body: %v", i, err)
 			continue
@@ -116,7 +116,7 @@ func TestJSONRPCID(t *testing.T) {
 		res := rec.Result()
 		// Always expecting back a JSONRPCResponse
 		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
-		blob, err := ioutil.ReadAll(res.Body)
+		blob, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Errorf("#%d: err reading body: %v", i, err)
 			continue
@@ -146,7 +146,7 @@ func TestRPCNotification(t *testing.T) {
 
 	// Always expecting back a JSONRPCResponse
 	require.True(t, statusOK(res.StatusCode), "should always return 2XX")
-	blob, err := ioutil.ReadAll(res.Body)
+	blob, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	require.Nil(t, err, "reading from the body should not give back an error")
 	require.Equal(t, len(blob), 0, "a notification SHOULD NOT be responded to by the server")
@@ -182,7 +182,7 @@ func TestRPCNotificationInBatch(t *testing.T) {
 		res := rec.Result()
 		// Always expecting back a JSONRPCResponse
 		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
-		blob, err := ioutil.ReadAll(res.Body)
+		blob, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Errorf("#%d: err reading body: %v", i, err)
 			continue

--- a/libs/tendermint/rpc/jsonrpc/server/http_server_test.go
+++ b/libs/tendermint/rpc/jsonrpc/server/http_server_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
@@ -55,7 +54,7 @@ func TestMaxOpenConnections(t *testing.T) {
 				return
 			}
 			defer r.Body.Close()
-			io.Copy(ioutil.Discard, r.Body)
+			io.Copy(io.Discard, r.Body)
 		}()
 	}
 	wg.Wait()
@@ -88,7 +87,7 @@ func TestServeTLS(t *testing.T) {
 	defer res.Body.Close()
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("some body"), body)
 }

--- a/libs/tendermint/state/state.go
+++ b/libs/tendermint/state/state.go
@@ -3,7 +3,7 @@ package state
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/okex/exchain/libs/tendermint/types"
@@ -200,7 +200,7 @@ func MakeGenesisStateFromFile(genDocFile string) (State, error) {
 
 // MakeGenesisDocFromFile reads and unmarshals genesis doc from the given file.
 func MakeGenesisDocFromFile(genDocFile string) (*types.GenesisDoc, error) {
-	genDocJSON, err := ioutil.ReadFile(genDocFile)
+	genDocJSON, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read GenesisDoc file: %v", err)
 	}

--- a/libs/tendermint/state/txindex/kv/kv_bench_test.go
+++ b/libs/tendermint/state/txindex/kv/kv_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	dbm "github.com/tendermint/tm-db"
@@ -16,7 +16,7 @@ import (
 )
 
 func BenchmarkTxSearch(b *testing.B) {
-	dbDir, err := ioutil.TempDir("", "benchmark_tx_search_test")
+	dbDir, err := os.MkdirTemp("", "benchmark_tx_search_test")
 	if err != nil {
 		b.Errorf("failed to create temporary directory: %s", err)
 	}

--- a/libs/tendermint/state/txindex/kv/kv_test.go
+++ b/libs/tendermint/state/txindex/kv/kv_test.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -318,7 +317,7 @@ func txResultWithEvents(events []abci.Event) *types.TxResult {
 }
 
 func benchmarkTxIndex(txsCount int64, b *testing.B) {
-	dir, err := ioutil.TempDir("", "tx_index_db")
+	dir, err := os.MkdirTemp("", "tx_index_db")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/libs/tendermint/test/docker/Dockerfile
+++ b/libs/tendermint/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.17
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/libs/tendermint/types/genesis.go
+++ b/libs/tendermint/types/genesis.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -145,7 +145,7 @@ func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 
 // GenesisDocFromFile reads JSON data from a file and unmarshalls it into a GenesisDoc.
 func GenesisDocFromFile(genDocFile string) (*GenesisDoc, error) {
-	jsonBlob, err := ioutil.ReadFile(genDocFile)
+	jsonBlob, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "Couldn't read GenesisDoc file")
 	}

--- a/libs/tendermint/types/genesis_test.go
+++ b/libs/tendermint/types/genesis_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestGenesisGood(t *testing.T) {
 }
 
 func TestGenesisSaveAs(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "genesis")
+	tmpfile, err := os.CreateTemp("", "genesis")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/libs/tendermint/types/part_set_test.go
+++ b/libs/tendermint/types/part_set_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +54,7 @@ func TestBasicPartSet(t *testing.T) {
 
 	// Reconstruct data, assert that they are equal.
 	data2Reader := partSet2.GetReader()
-	data2, err := ioutil.ReadAll(data2Reader)
+	data2, err := io.ReadAll(data2Reader)
 	require.NoError(t, err)
 
 	assert.Equal(t, data, data2)

--- a/networks/local/node/Dockerfile
+++ b/networks/local/node/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN make build-linux
 
 # Final image
-FROM golang:1.14 as final
+FROM golang:1.17 as final
 
 WORKDIR /okexchaind
 # Copy over binaries from the build-env
@@ -25,4 +25,3 @@ EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
 CMD ["start"]
 STOPSIGNAL SIGTERM
-

--- a/x/backend/config/config.go
+++ b/x/backend/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -67,7 +66,7 @@ func SafeLoadMaintainConfig(configDir string) (conf *Config, err error) {
 }
 
 func mustReadFile(filePath string) []byte {
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		fmt.Printf(fmt.Sprintf("mustReadFile failed: %v\n", err))
 		os.Exit(1)
@@ -77,7 +76,7 @@ func mustReadFile(filePath string) []byte {
 }
 
 func mustWriteFile(filePath string, contents []byte, mode os.FileMode) {
-	err := ioutil.WriteFile(filePath, contents, mode)
+	err := os.WriteFile(filePath, contents, mode)
 	if err != nil {
 		fmt.Printf(fmt.Sprintf("mustWriteFile failed: %v\n", err))
 		os.Exit(1)

--- a/x/dex/client/utils/utils.go
+++ b/x/dex/client/utils/utils.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -19,7 +19,7 @@ type DelistProposalJSON struct {
 
 // ParseDelistProposalJSON parse json from proposal file to DelistProposalJSON struct
 func ParseDelistProposalJSON(cdc *codec.Codec, proposalFilePath string) (proposal DelistProposalJSON, err error) {
-	contents, err := ioutil.ReadFile(proposalFilePath)
+	contents, err := os.ReadFile(proposalFilePath)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/distribution/client/cli/utils.go
+++ b/x/distribution/client/cli/utils.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -22,7 +22,7 @@ type (
 func ParseCommunityPoolSpendProposalJSON(cdc *codec.Codec, proposalFile string) (CommunityPoolSpendProposalJSON, error) {
 	proposal := CommunityPoolSpendProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/evm/client/utils/utils.go
+++ b/x/evm/client/utils/utils.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
-	"github.com/okex/exchain/x/evm/types"
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
+	"github.com/okex/exchain/x/evm/types"
 )
 
 type (
@@ -47,7 +47,7 @@ type (
 // struct
 func ParseManageContractDeploymentWhitelistProposalJSON(cdc *codec.Codec, proposalFilePath string) (
 	proposal ManageContractDeploymentWhitelistProposalJSON, err error) {
-	contents, err := ioutil.ReadFile(proposalFilePath)
+	contents, err := os.ReadFile(proposalFilePath)
 	if err != nil {
 		return
 	}
@@ -59,7 +59,7 @@ func ParseManageContractDeploymentWhitelistProposalJSON(cdc *codec.Codec, propos
 // ParseManageContractBlockedListProposalJSON parses json from proposal file to ManageContractBlockedListProposalJSON struct
 func ParseManageContractBlockedListProposalJSON(cdc *codec.Codec, proposalFilePath string) (
 	proposal ManageContractBlockedListProposalJSON, err error) {
-	contents, err := ioutil.ReadFile(proposalFilePath)
+	contents, err := os.ReadFile(proposalFilePath)
 	if err != nil {
 		return
 	}
@@ -71,7 +71,7 @@ func ParseManageContractBlockedListProposalJSON(cdc *codec.Codec, proposalFilePa
 // ParseManageContractMethodBlockedListProposalJSON parses json from proposal file to ManageContractBlockedListProposalJSON struct
 func ParseManageContractMethodBlockedListProposalJSON(cdc *codec.Codec, proposalFilePath string) (
 	proposal ManageContractMethodBlockedListProposalJSON, err error) {
-	contents, err := ioutil.ReadFile(proposalFilePath)
+	contents, err := os.ReadFile(proposalFilePath)
 	if err != nil {
 		return
 	}

--- a/x/evm/export_operation.go
+++ b/x/evm/export_operation.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,11 +11,11 @@ import (
 	"sync"
 	"sync/atomic"
 
-	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/okex/exchain/x/evm/types"
+	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
+	"github.com/okex/exchain/x/evm/types"
 	dbm "github.com/tendermint/tm-db"
 )
 
@@ -297,7 +296,7 @@ func syncReadCodeFromFile(ctx sdk.Context, logger log.Logger, k Keeper, address 
 	codeFilePath := filepath.Join(codePath, address.String()+codeFileSuffix)
 	if pathExist(codeFilePath) {
 		logger.Debug("start loading code", "filename", address.String()+codeFileSuffix)
-		bin, err := ioutil.ReadFile(codeFilePath)
+		bin, err := os.ReadFile(codeFilePath)
 		if err != nil {
 			panic(err)
 		}

--- a/x/evm/watcher/watcher.go
+++ b/x/evm/watcher/watcher.go
@@ -1,16 +1,14 @@
 package watcher
 
 import (
-	jsoniter "github.com/json-iterator/go"
 	"math/big"
 	"sync"
 
-	"github.com/okex/exchain/app/rpc/namespaces/eth/state"
-
-	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/okex/exchain/app/rpc/namespaces/eth/state"
+	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/auth"
 	"github.com/okex/exchain/libs/tendermint/abci/types"
 	tmstate "github.com/okex/exchain/libs/tendermint/state"

--- a/x/farm/client/utils/utils.go
+++ b/x/farm/client/utils/utils.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
+	"os"
+
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
-	"io/ioutil"
 )
 
 // ManageWhiteListProposalJSON defines a ManageWhiteListProposalJSON with a deposit used to parse manage white list
@@ -19,7 +20,7 @@ type ManageWhiteListProposalJSON struct {
 // ParseManageWhiteListProposalJSON parse json from proposal file to ManageWhiteListProposalJSON struct
 func ParseManageWhiteListProposalJSON(cdc *codec.Codec, proposalFilePath string) (proposal ManageWhiteListProposalJSON,
 	err error) {
-	contents, err := ioutil.ReadFile(proposalFilePath)
+	contents, err := os.ReadFile(proposalFilePath)
 	if err != nil {
 		return
 	}

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,11 +19,11 @@ import (
 	"github.com/okex/exchain/libs/cosmos-sdk/types/module"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/auth"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/auth/client/utils"
+	tmos "github.com/okex/exchain/libs/tendermint/libs/os"
+	tmtypes "github.com/okex/exchain/libs/tendermint/types"
 	"github.com/okex/exchain/x/genutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	tmos "github.com/okex/exchain/libs/tendermint/libs/os"
-	tmtypes "github.com/okex/exchain/libs/tendermint/types"
 )
 
 // GenTxCmd builds the application's gentx command
@@ -206,7 +205,7 @@ func makeOutputFilepath(rootDir, nodeID string) (string, error) {
 
 func readUnsignedGenTxFile(cdc *codec.Codec, r io.Reader) (auth.StdTx, error) {
 	var stdTx auth.StdTx
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return stdTx, err
 	}

--- a/x/genutil/collect.go
+++ b/x/genutil/collect.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -70,8 +69,7 @@ func CollectStdTxs(cdc *codec.Codec, moniker, genTxsDir string,
 	genDoc tmtypes.GenesisDoc, genAccIterator types.GenesisAccountsIterator,
 ) (appGenTxs []authtypes.StdTx, persistentPeers string, err error) {
 
-	var fos []os.FileInfo
-	fos, err = ioutil.ReadDir(genTxsDir)
+	fos, err := os.ReadDir(genTxsDir)
 	if err != nil {
 		return appGenTxs, persistentPeers, err
 	}
@@ -105,7 +103,7 @@ func CollectStdTxs(cdc *codec.Codec, moniker, genTxsDir string,
 
 		// get the genStdTx
 		var jsonRawTx []byte
-		if jsonRawTx, err = ioutil.ReadFile(filename); err != nil {
+		if jsonRawTx, err = os.ReadFile(filename); err != nil {
 			return appGenTxs, persistentPeers, err
 		}
 		var genStdTx authtypes.StdTx

--- a/x/gov/client/cli/parse.go
+++ b/x/gov/client/cli/parse.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	govutils "github.com/okex/exchain/x/gov/client/utils"
 	"github.com/spf13/viper"
@@ -27,7 +27,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		}
 	}
 
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/x/order/client/rest/rest_v2.go
+++ b/x/order/client/rest/rest_v2.go
@@ -2,15 +2,15 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
 	"github.com/okex/exchain/libs/cosmos-sdk/types"
 	"github.com/okex/exchain/libs/cosmos-sdk/types/rest"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/auth"
-	"github.com/gorilla/mux"
 	"github.com/okex/exchain/x/common"
 	"github.com/okex/exchain/x/order/keeper"
 	ordertype "github.com/okex/exchain/x/order/types"
@@ -81,7 +81,7 @@ func broadcastPlaceOrderRequest(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req BroadcastReq
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -109,7 +109,6 @@ func broadcastPlaceOrderRequest(cliCtx context.CLIContext) http.HandlerFunc {
 		//TODO: OrderID needs to be obtained when the new version of the interface is developed
 		orderID := ""
 
-
 		res2 := placeCancelOrderResponse{
 			res,
 			orderID,
@@ -133,7 +132,7 @@ func broadcastCancelOrderRequest(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req BroadcastReq
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/params/client/utils/utils.go
+++ b/x/params/client/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -63,7 +63,7 @@ func (pcj ParamChangesJSON) ToParamChanges() []params.ParamChange {
 func ParseParamChangeProposalJSON(cdc *codec.Codec, proposalFile string) (ParamChangeProposalJSON, error) {
 	var proposal ParamChangeProposalJSON
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/stream/common/kline/market.go
+++ b/x/stream/common/kline/market.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
 	"github.com/nacos-group/nacos-sdk-go/vo"
-	"github.com/okex/exchain/x/stream/nacos"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
+	"github.com/okex/exchain/x/stream/nacos"
 )
 
 func GetMarketServiceURL(urls string, nameSpace string, param vo.SelectOneHealthInstanceParam) (string, error) {
@@ -61,7 +61,7 @@ func RegisterNewTokenPair(tokenPairID int64, tokenPairName string, marketService
 		return errors.New(fmt.Sprintf("failed to send data to market server. error: %s", err.Error()))
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 
 	if resp.Status != "200 " || err != nil {
 		return errors.New(fmt.Sprintf("the response status code is %s (expecet: 200), receiveData: %s. error: %s", resp.Status, string(bodyBytes), err.Error()))

--- a/x/stream/distrlock/local_state_lock.go
+++ b/x/stream/distrlock/local_state_lock.go
@@ -2,7 +2,6 @@ package distrlock
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -61,7 +60,7 @@ func (s *LocalStateService) GetDistState(stateKey string) (state string, err err
 		return "", nil
 	}
 
-	bytes, err := ioutil.ReadFile(stateFilePath)
+	bytes, err := os.ReadFile(stateFilePath)
 	if err == nil {
 		state = string(bytes)
 	}
@@ -74,7 +73,7 @@ func (s *LocalStateService) SetDistState(stateKey string, stateValue string) err
 	defer s.mutex.Unlock()
 
 	stateFilePath := s.getFullPath(stateKey)
-	err := ioutil.WriteFile(stateFilePath, []byte(stateValue), 0600)
+	err := os.WriteFile(stateFilePath, []byte(stateValue), 0600)
 
 	return err
 }

--- a/x/stream/eureka/api.go
+++ b/x/stream/eureka/api.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -72,7 +72,7 @@ func getAllInstance(serverURL string) (*Applications, error) {
 		return nil, fmt.Errorf("status code is %d, require 200", resp.StatusCode)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func GetOneInstance(serverURL string, appName string) (*Application, error) {
 		return nil, fmt.Errorf("status code is %d, require 200", resp.StatusCode)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/x/stream/websocket/utils.go
+++ b/x/stream/websocket/utils.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
@@ -37,5 +37,5 @@ func gzipDecode(in []byte) ([]byte, error) {
 	reader := flate.NewReader(bytes.NewReader(in))
 	defer reader.Close()
 
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }

--- a/x/token/client/cli/tx.go
+++ b/x/token/client/cli/tx.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"bufio"
 	"fmt"
-	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/okex/exchain/libs/cosmos-sdk/client"
 	"github.com/okex/exchain/libs/cosmos-sdk/client/context"
+	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	"github.com/okex/exchain/libs/cosmos-sdk/x/auth"
@@ -254,7 +254,7 @@ func getCmdTokenMultiSend(cdc *codec.Codec) *cobra.Command {
 			}
 
 			if transfersFile != "" {
-				transferBytes, err := ioutil.ReadFile(transfersFile)
+				transferBytes, err := os.ReadFile(transfersFile)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since exchain has been upgraded to Go 1.17 (#1145), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

I have also reorganized the imports using ```goimport``` in some of the files.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] ~Wrote tests~ (No new tests required for refactoring)
- [ ] ~Updated relevant documentation (`docs/`)~ (The changes are transparent to the end users)
- [ ] ~Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`~ (I'm not too sure about this, the `CHANGELOG.md` seems outdated? The last entry was in year 2018)
- [x] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
