### PR TITLE
fix eth_getBalance result in fast-query mode

### DIFF
--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/okex/exchain/app/refund"
 	ethermint "github.com/okex/exchain/app/types"
 	bam "github.com/okex/exchain/libs/cosmos-sdk/baseapp"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
@@ -128,8 +129,13 @@ func handleMsgEthereumTx(ctx sdk.Context, k *Keeper, msg types.MsgEthereumTx) (*
 			pm := k.GenerateCSDBParams()
 			infCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 			sendAcc := pm.AccountKeeper.GetAccount(infCtx, sender.Bytes())
+			//fix sender's balance in watcher with refund fees
+			gasConsumed := ctx.GasMeter().GasConsumed()
+			fixedFees := refund.CaculateRefundFees(ctx, gasConsumed, msg.GetFee(), msg.Data.Price)
+			coins := sendAcc.GetCoins().Add2(fixedFees)
+			_ = sendAcc.SetCoins(coins)
 			if sendAcc != nil {
-				pm.Watcher.SaveAccount(sendAcc, true)
+				pm.Watcher.SaveAccount(sendAcc, false)
 			}
 			ctx.WithGasMeter(currentGasMeter)
 		}


### PR DESCRIPTION
BUG: In fast-query mode, for the sender in one transition , the result of eth_getBalance was incorrect --- we calculated the balance of the sender's account without considering the refund gas.
FIX : At the end of handleMsgEthereumTx, we update the balance of the sender's account with refund gas and save it to RPC db which is used to keep the account information in fast-query mode.
EDIT:
app/refund/refund.go : provide a public func to Calculate refund gas
x/evm/handler.go : at the end of handleMsgEthereumTx, fix the sender's account balance with refund gas

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
