### PR TITLE
reduce unnecessary string construction at non-debug levels

### DIFF
--- a/libs/tendermint/p2p/conn/connection.go
+++ b/libs/tendermint/p2p/conn/connection.go
@@ -52,6 +52,12 @@ const (
 type receiveCbFunc func(chID byte, msgBytes []byte)
 type errorCbFunc func(interface{})
 
+type bytesHexStringer []byte
+
+func (b bytesHexStringer) String() string {
+	return fmt.Sprintf("%X", []byte(b))
+}
+
 /*
 Each peer has one `MConnection` (multiplex connection) instance.
 
@@ -352,7 +358,9 @@ func (c *MConnection) Send(chID byte, msgBytes []byte) bool {
 		return false
 	}
 
-	c.Logger.Debug("Send", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
+	msgStringer := bytesHexStringer(msgBytes)
+
+	c.Logger.Debug("Send", "channel", chID, "conn", c, "msgBytes", msgStringer)
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]
@@ -369,7 +377,7 @@ func (c *MConnection) Send(chID byte, msgBytes []byte) bool {
 		default:
 		}
 	} else {
-		c.Logger.Debug("Send failed", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
+		c.Logger.Debug("Send failed", "channel", chID, "conn", c, "msgBytes", msgStringer)
 	}
 	return success
 }
@@ -644,7 +652,8 @@ FOR_LOOP:
 				break FOR_LOOP
 			}
 			if msgBytes != nil {
-				c.Logger.Debug("Received bytes", "chID", pkt.ChannelID, "msgBytes", fmt.Sprintf("%X", msgBytes))
+				msgStringer := bytesHexStringer(msgBytes)
+				c.Logger.Debug("Received bytes", "chID", pkt.ChannelID, "msgBytes", msgStringer)
 				// NOTE: This means the reactor.Receive runs in the same thread as the p2p recv routine
 				c.onReceive(pkt.ChannelID, msgBytes)
 			}

--- a/libs/tendermint/p2p/conn/connection_test.go
+++ b/libs/tendermint/p2p/conn/connection_test.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -603,4 +604,14 @@ func BenchmarkPacketAmino(b *testing.B) {
 			_, _ = cdc.MarshalBinaryLengthPrefixedWithRegisteredMarshaller(packet)
 		}
 	})
+}
+
+func TestBytesStringer(t *testing.T) {
+	var testData = []byte("test data !!!")
+	expect := fmt.Sprintf("%X", testData)
+	var testStringer = bytesHexStringer(testData)
+	actual := testStringer.String()
+	require.EqualValues(t, expect, actual)
+	actual = fmt.Sprintf("%s", testStringer)
+	require.EqualValues(t, expect, actual)
 }


### PR DESCRIPTION
use Stringer instead of fmt to reduce unnecessary string construction at non-debug levels

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
