### PR TITLE
fix not display proposer address when the node is not proposer

### DIFF
--- a/libs/tendermint/consensus/state.go
+++ b/libs/tendermint/consensus/state.go
@@ -911,22 +911,22 @@ func (cs *State) needProofBlock(height int64) bool {
 }
 
 func (cs *State) isBlockProducer() (string, string) {
-	bpAddr := ""
+	const len2display int = 6
+	bpAddr := cs.Validators.GetProposer().Address
+	bpStr := bpAddr.String()
+	if len(bpStr) > len2display {
+		bpStr = bpStr[:len2display]
+	}
 	isBlockProducer := "n"
 	if cs.privValidator != nil && cs.privValidatorPubKey != nil {
 		address := cs.privValidatorPubKey.Address()
 
-		if cs.isProposer != nil && cs.isProposer(address) {
+		if bytes.Equal(bpAddr, address) {
 			isBlockProducer = "y"
-			bpAddr = cs.Validators.GetProposer().Address.String()
-			const len2display int = 6
-			if len(bpAddr) > len2display {
-				bpAddr = bpAddr[:len2display]
-			}
 		}
 	}
 
-	return isBlockProducer, bpAddr
+	return isBlockProducer, bpStr
 }
 
 // Enter (CreateEmptyBlocks): from enterNewRound(height,round)
@@ -982,7 +982,7 @@ func (cs *State) enterPropose(height int64, round int) {
 		return
 	}
 	address := cs.privValidatorPubKey.Address()
-	
+
 	// if not a validator, we're done
 	if !cs.Validators.HasAddress(address) {
 		logger.Debug("This node is not a validator", "addr", address, "vals", cs.Validators)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
