### PR TITLE
Validate Chain-id and GenesisHeight while app inits and starts 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -33,6 +33,7 @@ import (
 	"github.com/okex/exchain/libs/tendermint/crypto/tmhash"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
 	tmos "github.com/okex/exchain/libs/tendermint/libs/os"
+	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 	"github.com/okex/exchain/x/ammswap"
 	"github.com/okex/exchain/x/backend"
 	"github.com/okex/exchain/x/common/analyzer"
@@ -195,6 +196,7 @@ func NewOKExChainApp(
 	invCheckPeriod uint,
 	baseAppOptions ...func(*bam.BaseApp),
 ) *OKExChainApp {
+	logger.Info(fmt.Sprintf("GenesisHeight<%d>", tendermintTypes.GetStartBlockHeight()))
 	onceLog.Do(func() {
 		iavllog := logger.With("module", "iavl")
 		logFunc := func(level int, format string, args ...interface{}) {
@@ -220,9 +222,10 @@ func NewOKExChainApp(
 	}
 	chainId := viper.GetString(flags.FlagChainID)
 	if err = okexchain.IsValidateChainIdWithGenesisHeight(chainId); err != nil {
-		logger.Error(fmt.Sprintf("the config of OKExChain was parsed error : %s", err.Error()))
+		logger.Error(err.Error())
 		panic(err)
 	}
+
 	cdc := okexchaincodec.MakeCodec(ModuleBasics)
 
 	// NOTE we use custom OKExChain transaction decoder that supports the sdk.Tx interface instead of sdk.StdTx

--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/okex/exchain/app/refund"
 	okexchain "github.com/okex/exchain/app/types"
 	bam "github.com/okex/exchain/libs/cosmos-sdk/baseapp"
+	"github.com/okex/exchain/libs/cosmos-sdk/client/flags"
 	"github.com/okex/exchain/libs/cosmos-sdk/codec"
 	"github.com/okex/exchain/libs/cosmos-sdk/server"
 	"github.com/okex/exchain/libs/cosmos-sdk/server/config"
@@ -56,6 +57,7 @@ import (
 	"github.com/okex/exchain/x/staking"
 	"github.com/okex/exchain/x/stream"
 	"github.com/okex/exchain/x/token"
+	"github.com/spf13/viper"
 	dbm "github.com/tendermint/tm-db"
 )
 
@@ -216,7 +218,11 @@ func NewOKExChainApp(
 		logger.Error(fmt.Sprintf("the config of OKExChain was parsed error : %s", err.Error()))
 		panic(err)
 	}
-
+	chainId := viper.GetString(flags.FlagChainID)
+	if err = okexchain.IsValidateChainIdWithGenesisHeight(chainId); err != nil {
+		logger.Error(fmt.Sprintf("the config of OKExChain was parsed error : %s", err.Error()))
+		panic(err)
+	}
 	cdc := okexchaincodec.MakeCodec(ModuleBasics)
 
 	// NOTE we use custom OKExChain transaction decoder that supports the sdk.Tx interface instead of sdk.StdTx

--- a/app/app.go
+++ b/app/app.go
@@ -33,7 +33,6 @@ import (
 	"github.com/okex/exchain/libs/tendermint/crypto/tmhash"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
 	tmos "github.com/okex/exchain/libs/tendermint/libs/os"
-	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 	"github.com/okex/exchain/x/ammswap"
 	"github.com/okex/exchain/x/backend"
 	"github.com/okex/exchain/x/common/analyzer"
@@ -196,7 +195,6 @@ func NewOKExChainApp(
 	invCheckPeriod uint,
 	baseAppOptions ...func(*bam.BaseApp),
 ) *OKExChainApp {
-	logger.Info(fmt.Sprintf("GenesisHeight<%d>", tendermintTypes.GetStartBlockHeight()))
 	onceLog.Do(func() {
 		iavllog := logger.With("module", "iavl")
 		logFunc := func(level int, format string, args ...interface{}) {
@@ -618,7 +616,7 @@ func PreRun(context *server.Context) {
 	appconfig.RegisterDynamicConfig(context.Logger.With("module", "config"))
 
 	// set config by node mode
-	SetNodeConfig(context)
+	setNodeConfig(context)
 
 	//download pprof
 	appconfig.PprofDownload(context)

--- a/app/node_mode.go
+++ b/app/node_mode.go
@@ -12,6 +12,7 @@ import (
 	abcitypes "github.com/okex/exchain/libs/tendermint/abci/types"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
 	"github.com/okex/exchain/libs/tendermint/mempool"
+	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 	evmtypes "github.com/okex/exchain/x/evm/types"
 	"github.com/okex/exchain/x/evm/watcher"
 	"github.com/spf13/viper"
@@ -94,6 +95,7 @@ func logStartingFlags(logger log.Logger) {
 		store.FlagIavlCacheSize:             viper.GetInt(store.FlagIavlCacheSize),
 		mempool.FlagEnablePendingPool:       viper.GetBool(mempool.FlagEnablePendingPool),
 		appconfig.FlagMaxGasUsedPerBlock:    viper.GetInt64(appconfig.FlagMaxGasUsedPerBlock),
+		tendermintTypes.FlagGenesisHeight:   tendermintTypes.GetStartBlockHeightStr(),
 	}
 	msg := "starting flags:"
 	for k, v := range flagMap {

--- a/app/node_mode.go
+++ b/app/node_mode.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 
 	appconfig "github.com/okex/exchain/app/config"
 	"github.com/okex/exchain/app/types"
@@ -17,8 +18,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-func SetNodeConfig(ctx *server.Context) {
+func setNodeConfig(ctx *server.Context) {
 	nodeMode := viper.GetString(types.FlagNodeMode)
+
+	ctx.Logger.Info("starting node","Genesis Height",
+		tendermintTypes.GetStartBlockHeight(), "node mode", nodeMode)
+
 	switch types.NodeMode(nodeMode) {
 	case types.RpcNode:
 		setRpcConfig(ctx)
@@ -26,12 +31,12 @@ func SetNodeConfig(ctx *server.Context) {
 		setValidatorConfig(ctx)
 	case types.ArchiveNode:
 		setArchiveConfig(ctx)
-	case "":
-		ctx.Logger.Info("The node mode is not set for this node")
 	default:
-		ctx.Logger.Error(
-			fmt.Sprintf("Wrong value (%s) is set for %s, the correct value should be one of %s, %s, and %s",
-				nodeMode, types.FlagNodeMode, types.RpcNode, types.ValidatorNode, types.ArchiveNode))
+		if len(nodeMode) > 0 {
+			ctx.Logger.Error(
+				fmt.Sprintf("Wrong value (%s) is set for %s, the correct value should be one of %s, %s, and %s",
+					nodeMode, types.FlagNodeMode, types.RpcNode, types.ValidatorNode, types.ArchiveNode))
+		}
 	}
 }
 
@@ -97,7 +102,7 @@ func logStartingFlags(logger log.Logger) {
 	}
 	msg := "starting flags:"
 	for k, v := range flagMap {
-		msg += fmt.Sprintf("	\n%s=%v", k, v)
+		msg += fmt.Sprintf("\n	%s=%v", k, v)
 	}
 
 	logger.Info(msg)

--- a/app/node_mode.go
+++ b/app/node_mode.go
@@ -12,7 +12,6 @@ import (
 	abcitypes "github.com/okex/exchain/libs/tendermint/abci/types"
 	"github.com/okex/exchain/libs/tendermint/libs/log"
 	"github.com/okex/exchain/libs/tendermint/mempool"
-	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 	evmtypes "github.com/okex/exchain/x/evm/types"
 	"github.com/okex/exchain/x/evm/watcher"
 	"github.com/spf13/viper"
@@ -95,7 +94,6 @@ func logStartingFlags(logger log.Logger) {
 		store.FlagIavlCacheSize:             viper.GetInt(store.FlagIavlCacheSize),
 		mempool.FlagEnablePendingPool:       viper.GetBool(mempool.FlagEnablePendingPool),
 		appconfig.FlagMaxGasUsedPerBlock:    viper.GetInt64(appconfig.FlagMaxGasUsedPerBlock),
-		tendermintTypes.FlagGenesisHeight:   tendermintTypes.GetStartBlockHeightStr(),
 	}
 	msg := "starting flags:"
 	for k, v := range flagMap {

--- a/app/types/chain_id.go
+++ b/app/types/chain_id.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/okex/exchain/libs/cosmos-sdk/types/errors"
+	tendermintTypes "github.com/okex/exchain/libs/tendermint/types"
 )
 
 var (
@@ -16,6 +17,9 @@ var (
 	ethermintChainID = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, regexChainID, regexSeparator, regexEpoch))
 )
 
+const mainnet_chain_id = "exchain-66"
+const testnet_chain_id = "exchain-65"
+
 // IsValidChainID returns false if the given chain identifier is incorrectly formatted.
 func IsValidChainID(chainID string) bool {
 	if len(chainID) > 48 {
@@ -23,6 +27,12 @@ func IsValidChainID(chainID string) bool {
 	}
 
 	return ethermintChainID.MatchString(chainID)
+}
+func IsMainNetChainID(chainID string) bool {
+	return chainID == mainnet_chain_id
+}
+func IsTestNetChainID(chainID string) bool {
+	return chainID == testnet_chain_id
 }
 
 // ParseChainID parses a string chain identifier's epoch to an Ethereum-compatible
@@ -45,4 +55,14 @@ func ParseChainID(chainID string) (*big.Int, error) {
 	}
 
 	return chainIDInt, nil
+}
+
+func IsValidateChainIdWithGenesisHeight(chainID string) error {
+	if tendermintTypes.IsMainNet() && !IsMainNetChainID(chainID) {
+		return fmt.Errorf("Must use <make mainnet> to rebuild if chain-id is <%s>, Current GenesisHeight is <%d>", chainID, tendermintTypes.GetStartBlockHeight())
+	} else if tendermintTypes.IsTestNet() && !IsMainNetChainID(chainID) {
+		return fmt.Errorf("Must use <make testnet> to rebuild if chain-id is <%s>, Current GenesisHeight is <%d>", chainID, tendermintTypes.GetStartBlockHeight())
+	} else {
+		return nil
+	}
 }

--- a/app/types/chain_id.go
+++ b/app/types/chain_id.go
@@ -17,8 +17,8 @@ var (
 	ethermintChainID = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, regexChainID, regexSeparator, regexEpoch))
 )
 
-const mainnet_chain_id = "exchain-66"
-const testnet_chain_id = "exchain-65"
+const mainnetChainId = "exchain-66"
+const testnetChainId = "exchain-65"
 
 // IsValidChainID returns false if the given chain identifier is incorrectly formatted.
 func IsValidChainID(chainID string) bool {
@@ -28,11 +28,11 @@ func IsValidChainID(chainID string) bool {
 
 	return ethermintChainID.MatchString(chainID)
 }
-func IsMainNetChainID(chainID string) bool {
-	return chainID == mainnet_chain_id
+func isMainNetChainID(chainID string) bool {
+	return chainID == mainnetChainId
 }
-func IsTestNetChainID(chainID string) bool {
-	return chainID == testnet_chain_id
+func isTestNetChainID(chainID string) bool {
+	return chainID == testnetChainId
 }
 
 // ParseChainID parses a string chain identifier's epoch to an Ethereum-compatible
@@ -58,11 +58,11 @@ func ParseChainID(chainID string) (*big.Int, error) {
 }
 
 func IsValidateChainIdWithGenesisHeight(chainID string) error {
-	if tendermintTypes.IsMainNet() && !IsMainNetChainID(chainID) {
+	if isMainNetChainID(chainID) && !tendermintTypes.IsMainNet() {
 		return fmt.Errorf("Must use <make mainnet> to rebuild if chain-id is <%s>, Current GenesisHeight is <%d>", chainID, tendermintTypes.GetStartBlockHeight())
-	} else if tendermintTypes.IsTestNet() && !IsMainNetChainID(chainID) {
-		return fmt.Errorf("Must use <make testnet> to rebuild if chain-id is <%s>, Current GenesisHeight is <%d>", chainID, tendermintTypes.GetStartBlockHeight())
-	} else {
-		return nil
 	}
+	if isTestNetChainID(chainID) && !tendermintTypes.IsTestNet() {
+		return fmt.Errorf("Must use <make testnet> to rebuild if chain-id is <%s>, Current GenesisHeight is <%d>", chainID, tendermintTypes.GetStartBlockHeight())
+	}
+	return nil
 }

--- a/cmd/client/config.go
+++ b/cmd/client/config.go
@@ -54,7 +54,9 @@ func ValidateChainID(baseCmd *cobra.Command) *cobra.Command {
 		if !ethermint.IsValidChainID(chainID) {
 			return fmt.Errorf("invalid chain-id format: %s", chainID)
 		}
-
+		if err := ethermint.IsValidateChainIdWithGenesisHeight(chainID); err != nil {
+			return err
+		}
 		return baseRunE(cmd, args)
 	}
 

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 KEY="captain"
-CHAINID="exchain-65"
+CHAINID="exchain-67"
 MONIKER="oec"
 CURDIR=`dirname $0`
 HOME_SERVER=$CURDIR/"_cache_evm"

--- a/libs/iavl/mutable_tree_oec.go
+++ b/libs/iavl/mutable_tree_oec.go
@@ -181,7 +181,7 @@ func (tree *MutableTree) loadVersionToCommittedHeightMap() {
 		tree.committedHeightMap[version] = true
 		tree.committedHeightQueue.PushBack(version)
 	}
-	tree.log(IavlInfo, "committedHeightQueue: %v", versionSlice)
+	tree.log(IavlInfo, "Tree<%s>, committed height queue: <%v>", tree.GetModuleName(), versionSlice)
 
 }
 

--- a/libs/tendermint/types/block.go
+++ b/libs/tendermint/types/block.go
@@ -37,6 +37,8 @@ const (
 	MaxAminoOverheadForBlock int64 = 11
 )
 
+const FlagGenesisHeight = "GenesisHeight"
+
 // GetStartBlockHeight() is the block height from which the chain starts
 var (
 	startBlockHeightStr       = "0"
@@ -63,6 +65,10 @@ func init() {
 
 func GetStartBlockHeight() int64 {
 	return startBlockHeight
+}
+
+func GetStartBlockHeightStr() string {
+	return startBlockHeightStr
 }
 
 // Block defines the atomic unit of a Tendermint blockchain.

--- a/libs/tendermint/types/block.go
+++ b/libs/tendermint/types/block.go
@@ -37,8 +37,6 @@ const (
 	MaxAminoOverheadForBlock int64 = 11
 )
 
-const FlagGenesisHeight = "GenesisHeight"
-
 // GetStartBlockHeight() is the block height from which the chain starts
 var (
 	startBlockHeightStr       = "0"
@@ -65,10 +63,6 @@ func init() {
 
 func GetStartBlockHeight() int64 {
 	return startBlockHeight
-}
-
-func GetStartBlockHeightStr() string {
-	return startBlockHeightStr
 }
 
 // Block defines the atomic unit of a Tendermint blockchain.


### PR DESCRIPTION
bug:
make mainnet, must use chain-id="exchain-66" while app starts or inits
make testnet, must use chain-id="exchain-65" while app starts or inits
otherwise,  may cause smb problem and data corruption

solution:
1、validate  Chain-id and GenesisHeight while app start flag is loading or app inits
2、if Chain-id is "exchain-66" ,validate if GenesisHeight is 2322600, if not. return err
3、if Chain-id is "exchain-65" ,validate if GenesisHeight is 1121818 , if not. return err
4、if Chain-id is neither "exchain-66" nor "exchain-65",  no need to validate GenesisHeight

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
