### PR TITLE
Add two hours buffer-time before VenusHeight upgrade to close txPool

### DIFF
--- a/app/rpc/namespaces/eth/api.go
+++ b/app/rpc/namespaces/eth/api.go
@@ -717,8 +717,15 @@ func (api *PublicEthereumAPI) SendTransaction(args rpctypes.SendTxArgs) (common.
 		return common.Hash{}, err
 	}
 
+	//todo: after upgrade of VenusHeight, this code need to be deleted, 1800 means two hours before arriving VenusHeight
+	VenusTxPoolHeight := int64(0)
+	if tmtypes.GetVenusHeight() < 1800 {
+		VenusTxPoolHeight = 0
+	} else {
+		VenusTxPoolHeight = tmtypes.GetVenusHeight() - 1800
+	}
 	// send chanData to txPool
-	if tmtypes.HigherThanVenus(int64(height)) && api.txPool != nil {
+	if (int64(height) < VenusTxPoolHeight || tmtypes.HigherThanVenus(int64(height))) && api.txPool != nil {
 		return broadcastTxByTxPool(api, tx, txBytes)
 	}
 
@@ -761,8 +768,15 @@ func (api *PublicEthereumAPI) SendRawTransaction(data hexutil.Bytes) (common.Has
 		}
 	}
 
+	//todo: after upgrade of VenusHeight, this code need to be deleted, 1800 means two hours before arriving VenusHeight
+	VenusTxPoolHeight := int64(0)
+	if tmtypes.GetVenusHeight() < 1800 {
+		VenusTxPoolHeight = 0
+	} else {
+		VenusTxPoolHeight = tmtypes.GetVenusHeight() - 1800
+	}
 	// send chanData to txPool
-	if tmtypes.HigherThanVenus(int64(height)) && api.txPool != nil {
+	if (int64(height) < VenusTxPoolHeight || tmtypes.HigherThanVenus(int64(height))) && api.txPool != nil {
 		return broadcastTxByTxPool(api, tx, txBytes)
 	}
 

--- a/app/rpc/namespaces/eth/api.go
+++ b/app/rpc/namespaces/eth/api.go
@@ -719,9 +719,7 @@ func (api *PublicEthereumAPI) SendTransaction(args rpctypes.SendTxArgs) (common.
 
 	//todo: after upgrade of VenusHeight, this code need to be deleted, 1800 means two hours before arriving VenusHeight
 	VenusTxPoolHeight := int64(0)
-	if tmtypes.GetVenusHeight() < 1800 {
-		VenusTxPoolHeight = 0
-	} else {
+	if tmtypes.GetVenusHeight() > 1800 {
 		VenusTxPoolHeight = tmtypes.GetVenusHeight() - 1800
 	}
 	// send chanData to txPool
@@ -770,9 +768,7 @@ func (api *PublicEthereumAPI) SendRawTransaction(data hexutil.Bytes) (common.Has
 
 	//todo: after upgrade of VenusHeight, this code need to be deleted, 1800 means two hours before arriving VenusHeight
 	VenusTxPoolHeight := int64(0)
-	if tmtypes.GetVenusHeight() < 1800 {
-		VenusTxPoolHeight = 0
-	} else {
+	if tmtypes.GetVenusHeight() > 1800 {
 		VenusTxPoolHeight = tmtypes.GetVenusHeight() - 1800
 	}
 	// send chanData to txPool


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
