### PR TITLE
fix eth_getBalance for fast-query treasures coin is error for v1.2.0

### DIFF
--- a/x/evm/watcher/watcher.go
+++ b/x/evm/watcher/watcher.go
@@ -374,9 +374,9 @@ func (w *Watcher) Commit() {
 	//hold it in temp
 	batch := w.batch
 	delayEraseKey := w.delayEraseKey
+	w.clean()
 	w.dispatchJob(func() {
 		w.commitBatch(batch, delayEraseKey)
-		w.clean()
 	})
 }
 


### PR DESCRIPTION
…d clean

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
