### PR TITLE
eth_getLogs return timeout error during stress testing

### DIFF
--- a/app/rpc/backend/backend.go
+++ b/app/rpc/backend/backend.go
@@ -457,7 +457,10 @@ func (b *EthermintBackend) GetLogs(blockHash common.Hash) ([][]*ethtypes.Log, er
 	if err != nil {
 		return nil, err
 	}
-
+	// return timeout error directly when block was produced during stress testing.
+	if len(block.Block.Txs) > b.logsLimit {
+		return nil, ErrTimeout
+	}
 	var blockLogs = [][]*ethtypes.Log{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.logsTimeout)*time.Second)
 	defer cancel()

--- a/app/rpc/backend/backend.go
+++ b/app/rpc/backend/backend.go
@@ -32,6 +32,7 @@ const (
 )
 
 var ErrTimeout = errors.New("query timeout exceeded")
+var ErrPressureTest = errors.New("the block was produced during pressure test")
 
 // Backend implements the functionality needed to filter changes.
 // Implemented by EthermintBackend.
@@ -459,7 +460,7 @@ func (b *EthermintBackend) GetLogs(blockHash common.Hash) ([][]*ethtypes.Log, er
 	}
 	// return timeout error directly when block was produced during stress testing.
 	if len(block.Block.Txs) > b.logsLimit {
-		return nil, ErrTimeout
+		return nil, ErrPressureTest
 	}
 	var blockLogs = [][]*ethtypes.Log{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.logsTimeout)*time.Second)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
