### PR TITLE
reuse packetMsg when unmarshal

### DIFF
--- a/libs/tendermint/p2p/conn/connection.go
+++ b/libs/tendermint/p2p/conn/connection.go
@@ -1071,6 +1071,12 @@ func (mp PacketMsg) String() string {
 	return fmt.Sprintf("PacketMsg{%X:%X T:%X}", mp.ChannelID, mp.Bytes, mp.EOF)
 }
 
+func (mp *PacketMsg) Reset() {
+	mp.ChannelID = 0
+	mp.EOF = 0
+	mp.Bytes = mp.Bytes[:0]
+}
+
 func (mp PacketMsg) AminoSize(_ *amino.Codec) int {
 	size := 0
 	if mp.ChannelID != 0 {
@@ -1292,9 +1298,7 @@ func unmarshalPacketFromAminoReader(r io.Reader, maxSize int64, targetMsg *Packe
 		var msg *PacketMsg
 		if targetMsg != nil {
 			msg = targetMsg
-			msg.ChannelID = 0
-			msg.EOF = 0
-			msg.Bytes = msg.Bytes[:0]
+			msg.Reset()
 		} else {
 			msg = &PacketMsg{}
 		}

--- a/libs/tendermint/p2p/conn/connection.go
+++ b/libs/tendermint/p2p/conn/connection.go
@@ -594,6 +594,7 @@ func (c *MConnection) sendPacketMsg() bool {
 func (c *MConnection) recvRoutine() {
 	defer c._recover()
 
+	var packetMsg PacketMsg
 FOR_LOOP:
 	for {
 		// Block until .recvMonitor says we can read.
@@ -618,7 +619,7 @@ FOR_LOOP:
 		var _n int64
 		var err error
 		// _n, err = cdc.UnmarshalBinaryLengthPrefixedReader(c.bufConnReader, &packet, int64(c._maxPacketMsgSize))
-		packet, _n, err = unmarshalPacketFromAminoReader(c.bufConnReader, int64(c._maxPacketMsgSize))
+		packet, _n, err = unmarshalPacketFromAminoReader(c.bufConnReader, int64(c._maxPacketMsgSize), &packetMsg)
 		c.recvMonitor.Update(int(_n))
 
 		if err != nil {
@@ -659,7 +660,7 @@ FOR_LOOP:
 			default:
 				// never block
 			}
-		case PacketMsg:
+		case *PacketMsg:
 			channel, ok := c.channelsIdx[pkt.ChannelID]
 			if !ok || channel == nil {
 				err := fmt.Errorf("unknown channel %X", pkt.ChannelID)
@@ -668,7 +669,7 @@ FOR_LOOP:
 				break FOR_LOOP
 			}
 
-			msgBytes, err := channel.recvPacketMsg(pkt)
+			msgBytes, err := channel.recvPacketMsg(*pkt)
 			if err != nil {
 				if c.IsRunning() {
 					c.Logger.Error("Connection failed @ recvRoutine", "conn", c, "err", err)
@@ -998,7 +999,7 @@ func RegisterPacket(cdc *amino.Codec) {
 	cdc.RegisterInterface((*Packet)(nil), nil)
 	cdc.RegisterConcrete(PacketPing{}, PacketPingName, nil)
 	cdc.RegisterConcrete(PacketPong{}, PacketPongName, nil)
-	cdc.RegisterConcrete(PacketMsg{}, PacketMsgName, nil)
+	cdc.RegisterConcrete(&PacketMsg{}, PacketMsgName, nil)
 
 	cdc.RegisterConcreteMarshaller(PacketPingName, func(_ *amino.Codec, i interface{}) ([]byte, error) {
 		return []byte{}, nil
@@ -1027,7 +1028,7 @@ func RegisterPacket(cdc *amino.Codec) {
 		if err != nil {
 			return nil, 0, err
 		} else {
-			return msg, len(data), nil
+			return &msg, len(data), nil
 		}
 	})
 
@@ -1192,7 +1193,11 @@ func (mp *PacketMsg) UnmarshalFromAmino(_ *amino.Codec, data []byte) error {
 			mp.EOF = byte(vari)
 			dataLen = uint64(n)
 		case 3:
-			mp.Bytes = make([]byte, len(subData))
+			if cap(mp.Bytes) >= len(subData) {
+				mp.Bytes = mp.Bytes[:len(subData)]
+			} else {
+				mp.Bytes = make([]byte, len(subData))
+			}
 			copy(mp.Bytes, subData)
 		}
 	}
@@ -1219,7 +1224,7 @@ var (
 	}
 )
 
-func unmarshalPacketFromAminoReader(r io.Reader, maxSize int64) (packet Packet, n int64, err error) {
+func unmarshalPacketFromAminoReader(r io.Reader, maxSize int64, targetMsg *PacketMsg) (packet Packet, n int64, err error) {
 	if maxSize < 0 {
 		panic("maxSize cannot be negative.")
 	}
@@ -1284,7 +1289,15 @@ func unmarshalPacketFromAminoReader(r io.Reader, maxSize int64) (packet Packet, 
 		packet = packetPong
 		return
 	} else if bytes.Equal(PacketMsgTypePrefix, bz[0:4]) {
-		msg := PacketMsg{}
+		var msg *PacketMsg
+		if targetMsg != nil {
+			msg = targetMsg
+			msg.ChannelID = 0
+			msg.EOF = 0
+			msg.Bytes = msg.Bytes[:0]
+		} else {
+			msg = &PacketMsg{}
+		}
 		err = msg.UnmarshalFromAmino(cdc, bz[4:])
 		if err == nil {
 			packet = msg

--- a/libs/tendermint/p2p/conn/connection_test.go
+++ b/libs/tendermint/p2p/conn/connection_test.go
@@ -573,7 +573,7 @@ func TestPacketAmino(t *testing.T) {
 
 		var buf bytes.Buffer
 		buf.Write(bz)
-		newPacket2, n, err := unmarshalPacketFromAminoReader(&buf, int64(buf.Len()))
+		newPacket2, n, err := unmarshalPacketFromAminoReader(&buf, int64(buf.Len()), nil)
 		require.NoError(t, err)
 		require.EqualValues(t, len(bz), n)
 
@@ -641,7 +641,7 @@ func BenchmarkPacketAmino(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var packet Packet
 			var buf = bytes.NewBuffer(bz)
-			packet, _, err = unmarshalPacketFromAminoReader(buf, int64(buf.Len()))
+			packet, _, err = unmarshalPacketFromAminoReader(buf, int64(buf.Len()), nil)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/libs/tendermint/p2p/conn/connection_test.go
+++ b/libs/tendermint/p2p/conn/connection_test.go
@@ -711,22 +711,22 @@ func TestPacketMsgAmino(t *testing.T) {
 		err = cdc.UnmarshalBinaryBare(expectData, &expectValue)
 		require.NoError(t, err)
 
-		var actulaValue PacketMsg
-		tmp, err := cdc.UnmarshalBinaryBareWithRegisteredUnmarshaller(expectData, &actulaValue)
+		var actulaValue = &PacketMsg{}
+		tmp, err := cdc.UnmarshalBinaryBareWithRegisteredUnmarshaller(expectData, actulaValue)
 		require.NoError(t, err)
-		_, ok := tmp.(PacketMsg)
+		_, ok := tmp.(*PacketMsg)
 		require.True(t, ok)
-		actulaValue = tmp.(PacketMsg)
+		actulaValue = tmp.(*PacketMsg)
 
-		require.EqualValues(t, expectValue, actulaValue)
+		require.EqualValues(t, expectValue, *actulaValue)
 		err = actulaValue.UnmarshalFromAmino(cdc, expectData[4:])
 		require.NoError(t, err)
-		require.EqualValues(t, expectValue, actulaValue)
+		require.EqualValues(t, expectValue, *actulaValue)
 
-		actulaValue = PacketMsg{}
-		err = cdc.UnmarshalBinaryLengthPrefixed(actualLenPrefixData, &actulaValue)
+		actulaValue = &PacketMsg{}
+		err = cdc.UnmarshalBinaryLengthPrefixed(actualLenPrefixData, actulaValue)
 		require.NoError(t, err)
-		require.EqualValues(t, expectValue, actulaValue)
+		require.EqualValues(t, expectValue, *actulaValue)
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
