### PR TITLE
fix prMsg when peer is not in validators

### DIFF
--- a/libs/tendermint/consensus/consensus_main_routine.go
+++ b/libs/tendermint/consensus/consensus_main_routine.go
@@ -265,7 +265,7 @@ func (cs *State) scheduleRound0(rs *cstypes.RoundState) {
 	if GetActiveVC() {
 		// itself is proposer, no need to request
 		isBlockProducer, _ := cs.isBlockProducer()
-		if isBlockProducer != "y" {
+		if isBlockProducer != "y" && cs.Validators.HasAddress(cs.privValidatorPubKey.Address()) {
 			// request for proposer of new height
 			prMsg := ProposeRequestMessage{Height: cs.Height, CurrentProposer: cs.Validators.GetProposer().Address, NewProposer: cs.privValidatorPubKey.Address()}
 			// todo only put all request into one channel

--- a/libs/tendermint/consensus/reactor.go
+++ b/libs/tendermint/consensus/reactor.go
@@ -385,6 +385,9 @@ func (conR *Reactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 
 			// verify the signature of prMsg
 			_, val := conR.conS.Validators.GetByAddress(msg.NewProposer)
+			if val == nil {
+				return
+			}
 			if err := msg.Verify(val.PubKey); err != nil {
 				conR.Logger.Error("reactor Verify Signature of ProposeRequestMessage", "err", err)
 				return


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
