### PR TITLE
multi batches upgrade  to fast storage

### DIFF
--- a/app/app_upgrade_test.go
+++ b/app/app_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/okex/exchain/libs/tendermint/libs/cli"
+	"github.com/okex/exchain/libs/tm-db/common"
 	"github.com/okex/exchain/x/wasm"
 	wasmkeeper "github.com/okex/exchain/x/wasm/keeper"
 	"github.com/spf13/viper"
@@ -692,6 +693,7 @@ func createKeysByCases(caseas []UpgradeCase) map[string]*sdk.KVStoreKey {
 ///
 type RecordMemDB struct {
 	db *dbm.MemDB
+	common.PlaceHolder
 }
 
 func (d *RecordMemDB) Get(bytes []byte) ([]byte, error) {

--- a/cmd/exchaind/base/db.go
+++ b/cmd/exchaind/base/db.go
@@ -1,0 +1,36 @@
+package base
+
+import (
+	"fmt"
+	"strings"
+
+	dbm "github.com/okex/exchain/libs/tm-db"
+)
+
+const (
+	AppDBName = "application.db"
+)
+
+func OpenDB(dir string, backend dbm.BackendType) (db dbm.DB, err error) {
+	switch {
+	case strings.HasSuffix(dir, ".db"):
+		dir = dir[:len(dir)-3]
+	case strings.HasSuffix(dir, ".db/"):
+		dir = dir[:len(dir)-4]
+	default:
+		return nil, fmt.Errorf("database directory must end with .db")
+	}
+	//doesn't work on windows!
+	cut := strings.LastIndex(dir, "/")
+	if cut == -1 {
+		return nil, fmt.Errorf("cannot cut paths on %s", dir)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("couldn't create db: %v", r)
+		}
+	}()
+	name := dir[cut+1:]
+	db = dbm.NewDB(name, backend, dir[:cut])
+	return db, nil
+}

--- a/cmd/exchaind/fss/create.go
+++ b/cmd/exchaind/fss/create.go
@@ -1,0 +1,79 @@
+package fss
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/okex/exchain/cmd/exchaind/base"
+	"github.com/okex/exchain/libs/cosmos-sdk/x/auth"
+	"github.com/okex/exchain/libs/iavl"
+	dbm "github.com/okex/exchain/libs/tm-db"
+	"github.com/okex/exchain/x/evm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create fast index for IAVL",
+	Long: `Create fast index for IAVL:
+This command is a tool to generate the IAVL fast index.
+It will take long based on the original database size.
+When the create lunched, it will show Upgrade to Fast IAVL...`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		iavl.SetEnableFastStorage(true)
+		storeKeys := getStoreKeys()
+		outputModules(storeKeys)
+
+		return createIndex(storeKeys)
+	},
+}
+
+func init() {
+	fssCmd.AddCommand(createCmd)
+}
+
+func getStoreKeys() []string {
+	return []string{
+		auth.StoreKey,
+		evm.StoreKey,
+	}
+}
+
+func outputModules(storeKeys []string) {
+	if iavl.OutputModules == nil {
+		iavl.OutputModules = make(map[string]int, len(storeKeys))
+	}
+	for _, key := range storeKeys {
+		iavl.OutputModules[key] = 1
+	}
+}
+
+func createIndex(storeKeys []string) error {
+	dataDir := viper.GetString(flagDataDir)
+	dbBackend := viper.GetString(flagDBBackend)
+	db, err := base.OpenDB(dataDir+base.AppDBName, dbm.BackendType(dbBackend))
+	if err != nil {
+		return fmt.Errorf("error opening dir %v backend %v DB: %w", dataDir, dbBackend, err)
+	}
+	defer db.Close()
+
+	for _, key := range storeKeys {
+		log.Printf("Upgrading.... %v\n", key)
+		prefix := []byte(fmt.Sprintf("s/k:%s/", key))
+
+		prefixDB := dbm.NewPrefixDB(db, prefix)
+
+		tree, err := iavl.NewMutableTree(prefixDB, 0)
+		if err != nil {
+			return err
+		}
+		_, err = tree.LoadVersion(0)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/exchaind/fss/fss.go
+++ b/cmd/exchaind/fss/fss.go
@@ -1,0 +1,30 @@
+package fss
+
+import (
+	"github.com/okex/exchain/libs/cosmos-sdk/server"
+	"github.com/okex/exchain/libs/iavl"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagDataDir   = "data_dir"
+	flagDBBackend = "db_backend"
+)
+
+func Command(ctx *server.Context) *cobra.Command {
+	iavl.SetLogger(ctx.Logger.With("module", "iavl"))
+	return fssCmd
+}
+
+var fssCmd = &cobra.Command{
+	Use:   "fss",
+	Short: "FSS is an auxiliary fast storage system to IAVL",
+	Long: `IAVL fast storage related commands:
+This command include a set of command of the IAVL fast storage.
+include create sub command`,
+}
+
+func init() {
+	fssCmd.PersistentFlags().StringP(flagDataDir, "d", "./", "The chain data file location")
+	fssCmd.PersistentFlags().String(flagDBBackend, "goleveldb", "Database backend: goleveldb | rocksdb")
+}

--- a/cmd/exchaind/iaviewer.go
+++ b/cmd/exchaind/iaviewer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	ethcmn "github.com/ethereum/go-ethereum/common"
+	"github.com/okex/exchain/cmd/exchaind/base"
 	"github.com/okex/exchain/libs/tendermint/crypto"
 
 	"github.com/gogo/protobuf/proto"
@@ -296,7 +297,7 @@ func iaviewerDiffCmd(ctx *iaviewerContext) *cobra.Command {
 
 // iaviewerPrintDiff reads different key-value from leveldb according two paths
 func iaviewerPrintDiff(ctx *iaviewerContext, version2 int) error {
-	db, err := OpenDB(ctx.DataDir, ctx.DbBackend)
+	db, err := base.OpenDB(ctx.DataDir, ctx.DbBackend)
 	if err != nil {
 		return fmt.Errorf("error opening DB: %w", err)
 	}
@@ -363,7 +364,7 @@ func iaviewerPrintDiff(ctx *iaviewerContext, version2 int) error {
 
 // iaviewerReadData reads key-value from leveldb
 func iaviewerReadData(ctx *iaviewerContext) error {
-	db, err := OpenDB(ctx.DataDir, ctx.DbBackend)
+	db, err := base.OpenDB(ctx.DataDir, ctx.DbBackend)
 	if err != nil {
 		return fmt.Errorf("error opening DB: %w", err)
 	}
@@ -399,7 +400,7 @@ func iaviewerReadData(ctx *iaviewerContext) error {
 }
 
 func iaviewerReadNodeData(ctx *iaviewerContext) error {
-	db, err := OpenDB(ctx.DataDir, ctx.DbBackend)
+	db, err := base.OpenDB(ctx.DataDir, ctx.DbBackend)
 	if err != nil {
 		return fmt.Errorf("error opening DB: %w", err)
 	}
@@ -469,7 +470,7 @@ func newNodeStringFromNodeJson(nodeJson *iavl.NodeJson) *nodeString {
 }
 
 func iaviewerStatus(ctx *iaviewerContext) error {
-	db, err := OpenDB(ctx.DataDir, ctx.DbBackend)
+	db, err := base.OpenDB(ctx.DataDir, ctx.DbBackend)
 	if err != nil {
 		return fmt.Errorf("error opening DB: %w", err)
 	}
@@ -493,7 +494,7 @@ func printIaviewerStatus(tree *iavl.MutableTree) {
 }
 
 func iaviewerVersions(ctx *iaviewerContext) error {
-	db, err := OpenDB(ctx.DataDir, ctx.DbBackend)
+	db, err := base.OpenDB(ctx.DataDir, ctx.DbBackend)
 	if err != nil {
 		return fmt.Errorf("error opening DB: %w", err)
 	}
@@ -865,30 +866,6 @@ func ReadTree(db dbm.DB, version int, prefix []byte, cacheSize int) (*iavl.Mutab
 	}
 	_, err = tree.LoadVersion(int64(version))
 	return tree, err
-}
-
-func OpenDB(dir string, backend dbm.BackendType) (db dbm.DB, err error) {
-	switch {
-	case strings.HasSuffix(dir, ".db"):
-		dir = dir[:len(dir)-3]
-	case strings.HasSuffix(dir, ".db/"):
-		dir = dir[:len(dir)-4]
-	default:
-		return nil, fmt.Errorf("database directory must end with .db")
-	}
-	//doesn't work on windows!
-	cut := strings.LastIndex(dir, "/")
-	if cut == -1 {
-		return nil, fmt.Errorf("cannot cut paths on %s", dir)
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("couldn't create db: %v", r)
-		}
-	}()
-	name := dir[cut+1:]
-	db = dbm.NewDB(name, backend, dir[:cut])
-	return db, nil
 }
 
 // parseWeaveKey assumes a separating : where all in front should be ascii,

--- a/cmd/exchaind/main.go
+++ b/cmd/exchaind/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/okex/exchain/app/logevents"
+	"github.com/okex/exchain/cmd/exchaind/fss"
 	"github.com/okex/exchain/cmd/exchaind/mpt"
 
 	"github.com/okex/exchain/app/rpc"
@@ -87,6 +88,7 @@ func main() {
 		repairStateCmd(ctx),
 		displayStateCmd(ctx),
 		mpt.MptCmd(ctx),
+		fss.Command(ctx),
 		// AddGenesisAccountCmd allows users to add accounts to the genesis file
 		AddGenesisAccountCmd(ctx, codecProxy.GetCdc(), app.DefaultNodeHome, app.DefaultCLIHome),
 		flags.NewCompletionCmd(rootCmd, true),

--- a/libs/iavl/mock/db_mock.go
+++ b/libs/iavl/mock/db_mock.go
@@ -48,6 +48,20 @@ func (mr *MockDBMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDB)(nil).Close))
 }
 
+// Compact mocks base method.
+func (m *MockDB) Compact() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Compact")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Compact indicates an expected call of Compact.
+func (mr *MockDBMockRecorder) Compact() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Compact", reflect.TypeOf((*MockDB)(nil).Compact))
+}
+
 // Delete mocks base method.
 func (m *MockDB) Delete(arg0 []byte) error {
 	m.ctrl.T.Helper()

--- a/libs/iavl/mutable_tree.go
+++ b/libs/iavl/mutable_tree.go
@@ -658,6 +658,13 @@ func (tree *MutableTree) enableFastStorageAndCommitIfNotEnabled() (bool, error) 
 		tree.ndb.storageVersion = defaultStorageVersionValue
 		return false, err
 	}
+
+	tree.log(IavlInfo, "Compacting IAVL...")
+	if err := tree.ndb.db.Compact(); err != nil {
+		tree.log(IavlErr, "Compacted IAVL...", "error", err.Error())
+	}
+	tree.log(IavlInfo, "Compacting IAVL done")
+
 	return true, nil
 }
 

--- a/libs/iavl/mutable_tree.go
+++ b/libs/iavl/mutable_tree.go
@@ -16,6 +16,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// when upgrade to fast IAVL every commitGap nodes will trigger a db commit.
+var commitGap uint64 = 10000000
+
+// when upgrade to fast IAVL every verboseGap nodes will trigger a print.
+const verboseGap = 50000
+
 func SetIgnoreVersionCheck(check bool) {
 	ignoreVersionCheck = check
 }
@@ -607,31 +613,42 @@ func (tree *MutableTree) enableFastStorageAndCommitIfNotEnabled() (bool, error) 
 	if !GetEnableFastStorage() {
 		return false, nil
 	}
-	shouldForceUpdate := tree.ndb.shouldForceFastStorageUpgrade()
-	isFastStorageEnabled := tree.ndb.hasUpgradedToFastStorage()
 
 	if !tree.IsUpgradeable() {
 		return false, nil
 	}
 
-	if isFastStorageEnabled && shouldForceUpdate {
-		// If there is a mismatch between which fast nodes are on disk and the live state due to temporary
-		// downgrade and subsequent re-upgrade, we cannot know for sure which fast nodes have been removed while downgraded,
-		// Therefore, there might exist stale fast nodes on disk. As a result, to avoid persisting the stale state, it might
-		// be worth to delete the fast nodes from disk.
-		batch := tree.NewBatch()
-		fastItr := newFastIterator(nil, nil, true, tree.ndb)
-		defer fastItr.Close()
-		for ; fastItr.Valid(); fastItr.Next() {
-			if err := tree.ndb.DeleteFastNode(fastItr.Key(), batch); err != nil {
-				return false, err
-			}
+	// If there is a mismatch between which fast nodes are on disk and the live state due to temporary
+	// downgrade and subsequent re-upgrade, we cannot know for sure which fast nodes have been removed while downgraded,
+	// Therefore, there might exist stale fast nodes on disk. As a result, to avoid persisting the stale state, it might
+	// be worth to delete the fast nodes from disk.
+	var deleteCounter uint64
+	deleteBatch := tree.NewBatch()
+	fastItr := newFastIterator(nil, nil, true, tree.ndb)
+	defer fastItr.Close()
+	for ; fastItr.Valid(); fastItr.Next() {
+		if deleteCounter%verboseGap == 0 {
+			tree.log(IavlInfo, "Deleting stale fast nodes...", "finished", deleteCounter, "db", tree.ndb.name)
 		}
-
-		if err := tree.ndb.Commit(batch); err != nil {
+		deleteCounter++
+		if err := tree.ndb.DeleteFastNode(fastItr.Key(), deleteBatch); err != nil {
 			return false, err
 		}
+		if deleteCounter%commitGap == 0 {
+			if err := tree.ndb.Commit(deleteBatch); err != nil {
+				return false, err
+			}
+			deleteBatch = tree.NewBatch()
+		}
 	}
+	if deleteCounter%commitGap != 0 {
+		if err := tree.ndb.Commit(deleteBatch); err != nil {
+			return false, err
+		}
+	} else {
+		deleteBatch.Close()
+	}
+	tree.log(IavlInfo, "Deleting stale fast nodes...", "done", deleteCounter, "db", tree.ndb.name)
 
 	// Force garbage collection before we proceed to enabling fast storage.
 	runtime.GC()
@@ -694,16 +711,22 @@ func (tree *MutableTree) enableFastStorageAndCommit(batch dbm.Batch) error {
 	itr := NewIterator(nil, nil, true, tree.ImmutableTree)
 	defer itr.Close()
 	var upgradedNodes uint64
-	const verboseGap = 50000
 	for ; itr.Valid(); itr.Next() {
+		if upgradedNodes%verboseGap == 0 {
+			tree.log(IavlInfo, "Upgrading to fast IAVL...", "finished", upgradedNodes, "db", tree.ndb.name)
+		}
+		upgradedNodes++
 		if err = tree.ndb.SaveFastNodeNoCache(NewFastNode(itr.Key(), itr.Value(), tree.version), batch); err != nil {
 			return err
 		}
-		upgradedNodes++
-		if upgradedNodes%verboseGap == 0 {
-			tree.log(IavlInfo, "Upgrading to fast IAVL...", "finished", upgradedNodes)
+		if upgradedNodes%commitGap == 0 {
+			if err := tree.ndb.Commit(batch); err != nil {
+				return err
+			}
+			batch = tree.NewBatch()
 		}
 	}
+	tree.log(IavlInfo, "Upgrading to fast IAVL...", "done", upgradedNodes, "db", tree.ndb.name)
 
 	if err = itr.Error(); err != nil {
 		return err

--- a/libs/iavl/mutable_tree_test.go
+++ b/libs/iavl/mutable_tree_test.go
@@ -831,6 +831,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	endFormat := fastKeyFormat.Key()
 	endFormat[0]++
 	dbMock.EXPECT().Iterator(startFormat, endFormat).Return(iterMock, nil).Times(1)
+	dbMock.EXPECT().Compact()
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(2)

--- a/libs/iavl/mutable_tree_test.go
+++ b/libs/iavl/mutable_tree_test.go
@@ -11,10 +11,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/okex/exchain/libs/iavl/mock"
+	db "github.com/okex/exchain/libs/tm-db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	db "github.com/okex/exchain/libs/tm-db"
 	"github.com/tendermint/go-amino"
 )
 
@@ -738,7 +737,7 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 	batchMock := mock.NewMockBatch(ctrl)
 
 	dbMock.EXPECT().Get(gomock.Any()).Return(nil, nil).Times(1)
-	dbMock.EXPECT().NewBatch().Return(batchMock).Times(1)
+	dbMock.EXPECT().NewBatch().Return(batchMock).Times(2)
 	dbMock.EXPECT().ReverseIterator(gomock.Any(), gomock.Any()).Return(rIterMock, nil).Times(2)
 
 	batchMock.EXPECT().Set(gomock.Any(), gomock.Any()).Return().Times(1)
@@ -748,7 +747,15 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 	require.NotNil(t, tree)
 	require.False(t, tree.IsFastCacheEnabled())
 
-	batchMock.EXPECT().Write().Return(expectedError).Times(1)
+	rIterMock.EXPECT().Close().Return().Times(2)
+
+	IterMock := mock.NewMockIterator(ctrl)
+	IterMock.EXPECT().Error().Return(nil)
+	IterMock.EXPECT().Valid().Return(false).Times(2)
+	IterMock.EXPECT().Close()
+	batchMock.EXPECT().Write().Return(expectedError)
+	batchMock.EXPECT().Close().Times(2)
+	dbMock.EXPECT().Iterator(gomock.Any(), gomock.Any()).Return(IterMock, nil).Times(1)
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 	require.ErrorIs(t, err, expectedError)
 	require.False(t, enabled)
@@ -889,9 +896,108 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	require.False(t, enabled)
 }
 
+func TestUpgradeStorageToFast_Success(t *testing.T) {
+	tmpCommitGap := commitGap
+	commitGap = 1000
+	defer func() {
+		commitGap = tmpCommitGap
+	}()
+
+	type fields struct {
+		nodeCount int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{"less than commit gap", fields{nodeCount: 100}},
+		{"equal to commit gap", fields{nodeCount: int(commitGap)}},
+		{"great than commit gap", fields{nodeCount: int(commitGap) + 100}},
+		{"two times commit gap", fields{nodeCount: int(commitGap) * 2}},
+		{"two times plus commit gap", fields{nodeCount: int(commitGap)*2 + 1}},
+	}
+
+	for _, tt := range tests {
+		treeMap.resetMap()
+		tree, mirror := setupTreeAndMirrorForUpgrade(t, tt.fields.nodeCount)
+		enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
+		require.Nil(t, err)
+		require.True(t, enabled)
+		t.Run(tt.name, func(t *testing.T) {
+			i := 0
+			iter := newFastIterator(nil, nil, true, tree.ndb)
+			for ; iter.Valid(); iter.Next() {
+				require.Equal(t, []byte(mirror[i][0]), iter.Key())
+				require.Equal(t, []byte(mirror[i][1]), iter.Value())
+				i++
+			}
+			require.Equal(t, len(mirror), i)
+		})
+	}
+}
+
+func TestUpgradeStorageToFast_Delete_Stale_Success(t *testing.T) {
+	// we delete fast node, in case of deadlock. we should limit the stale count lower than chBufferSize(64)
+	tmpCommitGap := commitGap
+	commitGap = 5
+	defer func() {
+		commitGap = tmpCommitGap
+	}()
+
+	valStale := "val_stale"
+	addStaleKey := func(ndb *nodeDB, staleCount int) {
+		var keyPrefix = "key"
+		for i := 0; i < staleCount; i++ {
+			key := fmt.Sprintf("%s_%d", keyPrefix, i)
+
+			node := NewFastNode([]byte(key), []byte(valStale), 100)
+			var buf bytes.Buffer
+			buf.Grow(node.encodedSize())
+			err := node.writeBytes(&buf)
+			require.NoError(t, err)
+			err = ndb.db.Set(ndb.fastNodeKey([]byte(key)), buf.Bytes())
+			require.NoError(t, err)
+		}
+	}
+	type fields struct {
+		nodeCount  int
+		staleCount int
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{"stale less than commit gap", fields{nodeCount: 100, staleCount: 4}},
+		{"stale equal to commit gap", fields{nodeCount: int(commitGap), staleCount: int(commitGap)}},
+		{"stale great than commit gap", fields{nodeCount: int(commitGap) + 100, staleCount: int(commitGap)*2 - 1}},
+		{"stale twice commit gap", fields{nodeCount: int(commitGap) + 100, staleCount: int(commitGap) * 2}},
+		{"stale great than twice commit gap", fields{nodeCount: int(commitGap), staleCount: int(commitGap)*2 + 1}},
+	}
+
+	for _, tt := range tests {
+		treeMap.resetMap()
+		tree, mirror := setupTreeAndMirrorForUpgrade(t, tt.fields.nodeCount)
+		addStaleKey(tree.ndb, tt.fields.staleCount)
+		enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
+		require.Nil(t, err)
+		require.True(t, enabled)
+		t.Run(tt.name, func(t *testing.T) {
+			i := 0
+			iter := newFastIterator(nil, nil, true, tree.ndb)
+			for ; iter.Valid(); iter.Next() {
+				require.Equal(t, []byte(mirror[i][0]), iter.Key())
+				require.Equal(t, []byte(mirror[i][1]), iter.Value())
+				i++
+			}
+			require.Equal(t, len(mirror), i)
+		})
+	}
+}
+
 func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testing.T) {
 	// Setup
-	tree, mirror := setupTreeAndMirrorForUpgrade(t)
+	tree, mirror := setupTreeAndMirrorForUpgrade(t, 100)
 
 	require.False(t, tree.IsFastCacheEnabled())
 	require.True(t, tree.IsUpgradeable())
@@ -943,7 +1049,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 
 func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T) {
 	// Setup
-	tree, mirror := setupTreeAndMirrorForUpgrade(t)
+	tree, mirror := setupTreeAndMirrorForUpgrade(t, 100)
 
 	require.False(t, tree.IsFastCacheEnabled())
 	require.True(t, tree.IsUpgradeable())
@@ -985,12 +1091,11 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	})
 }
 
-func setupTreeAndMirrorForUpgrade(t *testing.T) (*MutableTree, [][]string) {
+func setupTreeAndMirrorForUpgrade(t *testing.T, numEntries int) (*MutableTree, [][]string) {
 	db := db.NewMemDB()
 
 	tree, _ := NewMutableTree(db, 0)
 
-	const numEntries = 100
 	var keyPrefix, valPrefix = "key", "val"
 
 	mirror := make([][]string, 0, numEntries)

--- a/libs/iavl/nodedb.go
+++ b/libs/iavl/nodedb.go
@@ -780,6 +780,7 @@ func (ndb *nodeDB) getFastIterator(start, end []byte, ascending bool) (dbm.Itera
 
 // Write to disk.
 func (ndb *nodeDB) Commit(batch dbm.Batch) error {
+	defer batch.Close()
 	ndb.log(IavlDebug, "committing data to disk")
 	var err error
 	if ndb.opts.Sync {
@@ -790,8 +791,6 @@ func (ndb *nodeDB) Commit(batch dbm.Batch) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to write batch")
 	}
-
-	batch.Close()
 
 	return nil
 }

--- a/libs/tm-db/boltdb.go
+++ b/libs/tm-db/boltdb.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/okex/exchain/libs/tm-db/common"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
@@ -32,6 +33,7 @@ func init() {
 // lead to performance issues when/if there will be lots of keys.
 type BoltDB struct {
 	db *bbolt.DB
+	common.PlaceHolder
 }
 
 var _ DB = (*BoltDB)(nil)

--- a/libs/tm-db/cleveldb.go
+++ b/libs/tm-db/cleveldb.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/jmhodges/levigo"
+	"github.com/okex/exchain/libs/tm-db/common"
 )
 
 func init() {
@@ -23,6 +24,7 @@ type CLevelDB struct {
 	ro     *levigo.ReadOptions
 	wo     *levigo.WriteOptions
 	woSync *levigo.WriteOptions
+	common.PlaceHolder
 }
 
 var _ DB = (*CLevelDB)(nil)

--- a/libs/tm-db/common/placeholder.go
+++ b/libs/tm-db/common/placeholder.go
@@ -1,0 +1,7 @@
+package common
+
+type PlaceHolder struct{}
+
+func (ph PlaceHolder) Compact() error {
+	return nil
+}

--- a/libs/tm-db/goleveldb.go
+++ b/libs/tm-db/goleveldb.go
@@ -229,3 +229,7 @@ func (db *GoLevelDB) ReverseIterator(start, end []byte) (Iterator, error) {
 	itr := db.db.NewIterator(&util.Range{Start: start, Limit: end}, nil)
 	return newGoLevelDBIterator(itr, start, end, true), nil
 }
+
+func (db *GoLevelDB) Compact() error {
+	return db.DB().CompactRange(util.Range{})
+}

--- a/libs/tm-db/memdb.go
+++ b/libs/tm-db/memdb.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/google/btree"
+	"github.com/okex/exchain/libs/tm-db/common"
 )
 
 const (
@@ -51,6 +52,7 @@ func newPair(key, value []byte) *item {
 type MemDB struct {
 	mtx   sync.RWMutex
 	btree *btree.BTree
+	common.PlaceHolder
 }
 
 var _ DB = (*MemDB)(nil)

--- a/libs/tm-db/prefixdb.go
+++ b/libs/tm-db/prefixdb.go
@@ -145,3 +145,7 @@ func (pdb *PrefixDB) Stats() map[string]string {
 func (pdb *PrefixDB) prefixed(key []byte) []byte {
 	return concat(pdb.prefix, key)
 }
+
+func (pdb *PrefixDB) Compact() error {
+	return pdb.db.Compact()
+}

--- a/libs/tm-db/remotedb/remotedb.go
+++ b/libs/tm-db/remotedb/remotedb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okex/exchain/libs/tm-db/common"
 	"github.com/pkg/errors"
 
 	db "github.com/okex/exchain/libs/tm-db"
@@ -14,6 +15,7 @@ import (
 type RemoteDB struct {
 	ctx context.Context
 	dc  protodb.DBClient
+	common.PlaceHolder
 }
 
 func NewRemoteDB(serverAddr string, serverKey string) (*RemoteDB, error) {

--- a/libs/tm-db/rocksdb.go
+++ b/libs/tm-db/rocksdb.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/spf13/viper"
 	"github.com/cosmos/gorocksdb"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -257,4 +257,9 @@ func (db *RocksDB) Iterator(start, end []byte) (Iterator, error) {
 func (db *RocksDB) ReverseIterator(start, end []byte) (Iterator, error) {
 	itr := db.db.NewIterator(db.ro)
 	return NewRocksDBIterator(itr, start, end, true), nil
+}
+
+func (db *RocksDB) Compact() error {
+	db.DB().CompactRange(gorocksdb.Range{})
+	return nil
 }

--- a/libs/tm-db/types.go
+++ b/libs/tm-db/types.go
@@ -59,6 +59,9 @@ type DB interface {
 
 	// Stats returns a map of property values for all keys and the size of the cache.
 	Stats() map[string]string
+
+	// Compact compact the database
+	Compact() error
 }
 
 // Batch represents a group of writes. They may or may not be written atomically depending on the


### PR DESCRIPTION
When upgrade to fast IAVL. use one batch may cause OOM.so upgrade use multi batches.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
