### PR TITLE
Merge PR: fix get_storageAt bugs in fast-query lru (#2428)

### DIFF
--- a/app/rpc/namespaces/eth/state/lru.go
+++ b/app/rpc/namespaces/eth/state/lru.go
@@ -5,8 +5,7 @@ import (
 	"sync"
 
 	"github.com/spf13/viper"
-
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/tendermint/go-amino"
 
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -38,12 +37,12 @@ func InstanceOfStateLru() *lru.Cache {
 	return gStateLru
 }
 
-func GetStateFromLru(key common.Hash) []byte {
+func GetStateFromLru(key []byte) []byte {
 	cache := InstanceOfStateLru()
 	if cache == nil {
 		return nil
 	}
-	value, ok := cache.Get(key)
+	value, ok := cache.Get(amino.BytesToStr(key))
 	if ok {
 		ret, ok := value.([]byte)
 		if ok {
@@ -53,10 +52,10 @@ func GetStateFromLru(key common.Hash) []byte {
 	return nil
 }
 
-func SetStateToLru(key common.Hash, value []byte) {
+func SetStateToLru(key []byte, value []byte) {
 	cache := InstanceOfStateLru()
 	if cache == nil {
 		return
 	}
-	cache.Add(key, value)
+	cache.Add(amino.BytesToStr(key), value)
 }

--- a/x/evm/watcher/querier.go
+++ b/x/evm/watcher/querier.go
@@ -440,8 +440,7 @@ func (q Querier) DeleteAccountFromRdb(addr sdk.AccAddress) {
 
 func (q Querier) MustGetState(addr common.Address, key []byte) ([]byte, error) {
 	orgKey := GetMsgStateKey(addr, key)
-	realKey := common.BytesToHash(orgKey)
-	data := state.GetStateFromLru(realKey)
+	data := state.GetStateFromLru(orgKey)
 	if data != nil {
 		return data, nil
 	}
@@ -452,7 +451,7 @@ func (q Querier) MustGetState(addr common.Address, key []byte) ([]byte, error) {
 		q.DeleteStateFromRdb(addr, key)
 	}
 	if e == nil {
-		state.SetStateToLru(realKey, b)
+		state.SetStateToLru(orgKey, b)
 	}
 	return b, e
 }

--- a/x/evm/watcher/watcher.go
+++ b/x/evm/watcher/watcher.go
@@ -378,7 +378,7 @@ func (w *Watcher) commitBatch(batch []WatchMessage) {
 				w.store.SetEvmParams(msgParams.Params)
 			}
 			if typeValue == TypeState {
-				state.SetStateToLru(common.BytesToHash(key), value)
+				state.SetStateToLru(key, value)
 			}
 		}
 	}
@@ -405,7 +405,7 @@ func (w *Watcher) commitCenterBatch(batch []*Batch) {
 		} else {
 			dbBatch.Set(b.Key, b.Value)
 			if b.TypeValue == TypeState {
-				state.SetStateToLru(common.BytesToHash(b.Key), b.Value)
+				state.SetStateToLru(b.Key, b.Value)
 			}
 		}
 	}


### PR DESCRIPTION
* fix get_storageAt bugs

* use amino for performance

* use amino for performance

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
