### PR TITLE
Add lock for MutableTree.unsavedAdditons and MutableTree.unsavedRemovals

### DIFF
--- a/libs/cosmos-sdk/baseapp/baseapp_mode_simulate.go
+++ b/libs/cosmos-sdk/baseapp/baseapp_mode_simulate.go
@@ -12,18 +12,13 @@ func (m *modeHandlerSimulate) handleStartHeight(info *runTxInfo, height int64) e
 	startHeight := tmtypes.GetStartBlockHeight()
 
 	var err error
-	lastHeight := app.LastBlockHeight()
-	if height == 0 {
-		height = lastHeight
-	}
-	if height <= startHeight {
+	if height > startHeight && height < app.LastBlockHeight() {
+		info.ctx, err = app.getContextForSimTx(info.txBytes, height)
+	} else if height < startHeight && height != 0 {
 		err = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
 			fmt.Sprintf("height(%d) should be greater than start block height(%d)", height, startHeight))
-	} else if height > startHeight && height <= lastHeight {
-		info.ctx, err = app.getContextForSimTx(info.txBytes, height)
 	} else {
-		err = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
-			fmt.Sprintf("height(%d) should be less than or equal to latest block height(%d)", height, lastHeight))
+		info.ctx = app.getContextForTx(m.mode, info.txBytes)
 	}
 	if info.overridesBytes != nil {
 		info.ctx.SetOverrideBytes(info.overridesBytes)

--- a/libs/cosmos-sdk/baseapp/baseapp_mode_simulate.go
+++ b/libs/cosmos-sdk/baseapp/baseapp_mode_simulate.go
@@ -12,13 +12,18 @@ func (m *modeHandlerSimulate) handleStartHeight(info *runTxInfo, height int64) e
 	startHeight := tmtypes.GetStartBlockHeight()
 
 	var err error
-	if height > startHeight && height < app.LastBlockHeight() {
-		info.ctx, err = app.getContextForSimTx(info.txBytes, height)
-	} else if height < startHeight && height != 0 {
+	lastHeight := app.LastBlockHeight()
+	if height == 0 {
+		height = lastHeight
+	}
+	if height <= startHeight {
 		err = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
 			fmt.Sprintf("height(%d) should be greater than start block height(%d)", height, startHeight))
+	} else if height > startHeight && height <= lastHeight {
+		info.ctx, err = app.getContextForSimTx(info.txBytes, height)
 	} else {
-		info.ctx = app.getContextForTx(m.mode, info.txBytes)
+		err = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
+			fmt.Sprintf("height(%d) should be less than or equal to latest block height(%d)", height, lastHeight))
 	}
 	if info.overridesBytes != nil {
 		info.ctx.SetOverrideBytes(info.overridesBytes)

--- a/libs/iavl/fast_iterator_okc.go
+++ b/libs/iavl/fast_iterator_okc.go
@@ -18,10 +18,11 @@ func NewFastIteratorWithCache(start, end []byte, ascending bool, ndb *nodeDB) *F
 		return iter
 	}
 	var fnc *fastNodeChanges
+
 	if ndb.tpfv != nil {
 		fnc = ndb.tpfv.expand(ndb.prePersistFastNode)
 	} else {
-		fnc = ndb.prePersistFastNode
+		fnc = ndb.prePersistFastNode.clone()
 	}
 
 	iter.UnsavedFastIterator = newUnsavedFastIterator(start, end, ascending, ndb, fnc.additions, fnc.removals)

--- a/libs/iavl/mutable_tree_oec.go
+++ b/libs/iavl/mutable_tree_oec.go
@@ -115,9 +115,9 @@ func (tree *MutableTree) updateBranchFastNode() {
 	if !GetEnableFastStorage() {
 		return
 	}
-	tree.ndb.updateBranchForFastNode(tree.unsavedFastNodeAdditions, tree.unsavedFastNodeRemovals)
-	tree.unsavedFastNodeAdditions = make(map[string]*FastNode)
-	tree.unsavedFastNodeRemovals = make(map[string]interface{})
+
+	tree.ndb.updateBranchForFastNode(tree.unsavedFastNodes)
+	tree.unsavedFastNodes.reset()
 }
 
 func (tree *MutableTree) setNewWorkingTree(version int64, persisted bool) ([]byte, int64, error) {

--- a/libs/iavl/nodedb_fnc.go
+++ b/libs/iavl/nodedb_fnc.go
@@ -2,11 +2,14 @@ package iavl
 
 import (
 	"sync"
+
+	"github.com/tendermint/go-amino"
 )
 
 type fastNodeChanges struct {
 	additions map[string]*FastNode
 	removals  map[string]interface{}
+	mtx       sync.RWMutex
 }
 
 func newFastNodeChanges() *fastNodeChanges {
@@ -17,6 +20,8 @@ func newFastNodeChanges() *fastNodeChanges {
 }
 
 func (fnc *fastNodeChanges) get(key []byte) (*FastNode, bool) {
+	fnc.mtx.RLock()
+	defer fnc.mtx.RUnlock()
 	if node, ok := fnc.additions[string(key)]; ok {
 		return node, true
 	}
@@ -27,25 +32,46 @@ func (fnc *fastNodeChanges) get(key []byte) (*FastNode, bool) {
 	return nil, false
 }
 
-func (fnc *fastNodeChanges) add(key string, fastNode *FastNode) {
-	fnc.additions[key] = fastNode
-	delete(fnc.removals, key)
+func (fnc *fastNodeChanges) add(key []byte, fastNode *FastNode) {
+	fnc.mtx.Lock()
+	fnc.additions[string(key)] = fastNode
+	delete(fnc.removals, string(key))
+	fnc.mtx.Unlock()
 }
 
-func (fnc *fastNodeChanges) remove(key string, value interface{}) {
-	fnc.removals[key] = value
-	delete(fnc.additions, key)
+func (fnc *fastNodeChanges) addAdditions(key []byte, fastNode *FastNode) {
+	fnc.mtx.Lock()
+	fnc.additions[string(key)] = fastNode
+	fnc.mtx.Unlock()
 }
 
-func (fnc *fastNodeChanges) checkRemovals(key string) bool {
-	if _, ok := fnc.removals[key]; ok {
+func (fnc *fastNodeChanges) remove(key []byte, value interface{}) {
+	fnc.mtx.Lock()
+	fnc.removals[string(key)] = value
+	delete(fnc.additions, string(key))
+	fnc.mtx.Unlock()
+}
+
+func (fnc *fastNodeChanges) addRemovals(key []byte) {
+	fnc.mtx.Lock()
+	fnc.removals[string(key)] = true
+	fnc.mtx.Unlock()
+}
+
+func (fnc *fastNodeChanges) checkRemovals(key []byte) bool {
+	fnc.mtx.RLock()
+	defer fnc.mtx.RUnlock()
+
+	if _, ok := fnc.removals[string(key)]; ok {
 		return true
 	}
 	return false
 }
 
-func (fnc *fastNodeChanges) checkAdditions(key string) bool {
-	if _, ok := fnc.additions[key]; ok {
+func (fnc *fastNodeChanges) checkAdditions(key []byte) bool {
+	fnc.mtx.RLock()
+	defer fnc.mtx.RUnlock()
+	if _, ok := fnc.additions[string(key)]; ok {
 		return true
 	}
 
@@ -64,13 +90,22 @@ func (fnc *fastNodeChanges) clone() *fastNodeChanges {
 	if fnc == nil {
 		return nil
 	}
-	additions := make(map[string]*FastNode, len(fnc.additions))
-	for k, v := range fnc.additions {
-		additions[k] = v
+	fnc.mtx.RLock()
+	defer fnc.mtx.RUnlock()
+	var additions map[string]*FastNode
+	if fnc.additions != nil {
+		additions = make(map[string]*FastNode, len(fnc.additions))
+		for k, v := range fnc.additions {
+			additions[k] = v
+		}
 	}
-	removals := make(map[string]interface{}, len(fnc.removals))
-	for k, v := range fnc.removals {
-		removals[k] = v
+
+	var removals map[string]interface{}
+	if fnc.removals != nil {
+		removals = make(map[string]interface{}, len(fnc.removals))
+		for k, v := range fnc.removals {
+			removals[k] = v
+		}
 	}
 	return &fastNodeChanges{
 		additions: additions,
@@ -78,24 +113,47 @@ func (fnc *fastNodeChanges) clone() *fastNodeChanges {
 	}
 }
 
-func (fnc *fastNodeChanges) merge(src *fastNodeChanges) *fastNodeChanges {
+// mergePrev merge previous to fnc, prev is old than fnc
+func (fnc *fastNodeChanges) mergePrev(prev *fastNodeChanges) *fastNodeChanges {
 	if fnc == nil {
-		return src
+		return prev
 	}
-	if src == nil {
+	if prev == nil {
 		return fnc
 	}
-	for k, v := range src.additions {
-		if !fnc.checkAdditions(k) && !fnc.checkRemovals(k) {
-			fnc.add(k, v)
+
+	for k, v := range prev.additions {
+		if !fnc.checkAdditions(amino.StrToBytes(k)) && !fnc.checkRemovals(amino.StrToBytes(k)) {
+			fnc.add(amino.StrToBytes(k), v)
 		}
 	}
-	for k, v := range src.removals {
-		if !fnc.checkAdditions(k) && !fnc.checkRemovals(k) {
-			fnc.remove(k, v)
+	for k, v := range prev.removals {
+		if !fnc.checkAdditions(amino.StrToBytes(k)) && !fnc.checkRemovals(amino.StrToBytes(k)) {
+			fnc.remove(amino.StrToBytes(k), v)
 		}
 	}
 	return fnc
+}
+
+// mergeLater merge later to fnc, later is new than fnc
+func (fnc *fastNodeChanges) mergeLater(later *fastNodeChanges) {
+	for k, v := range later.additions {
+		fnc.add(amino.StrToBytes(k), v)
+	}
+	for k, v := range later.removals {
+		fnc.remove(amino.StrToBytes(k), v)
+	}
+}
+
+func (fnc *fastNodeChanges) reset() {
+	fnc.mtx.Lock()
+	for k := range fnc.additions {
+		delete(fnc.additions, k)
+	}
+	for k := range fnc.removals {
+		delete(fnc.removals, k)
+	}
+	fnc.mtx.Unlock()
 }
 
 type fastNodeChangesWithVersion struct {
@@ -147,13 +205,13 @@ func (fncv *fastNodeChangesWithVersion) expand(changes *fastNodeChanges) *fastNo
 	}
 	for i := len(fncv.versions) - 1; i >= 0; i-- {
 		for k, v := range fncv.fncMap[fncv.versions[i]].additions {
-			if !ret.checkAdditions(k) && !ret.checkRemovals(k) {
-				ret.add(k, v)
+			if !ret.checkAdditions(amino.StrToBytes(k)) && !ret.checkRemovals(amino.StrToBytes(k)) {
+				ret.add(amino.StrToBytes(k), v)
 			}
 		}
 		for k, v := range fncv.fncMap[fncv.versions[i]].removals {
-			if !ret.checkAdditions(k) && !ret.checkRemovals(k) {
-				ret.remove(k, v)
+			if !ret.checkAdditions(amino.StrToBytes(k)) && !ret.checkRemovals(amino.StrToBytes(k)) {
+				ret.remove(amino.StrToBytes(k), v)
 			}
 		}
 	}

--- a/libs/iavl/nodedb_update_branch.go
+++ b/libs/iavl/nodedb_update_branch.go
@@ -129,14 +129,9 @@ func updateBranchAndSaveNodeToChan(node *Node, saveNodesCh chan<- *Node) []byte 
 	return node.hash
 }
 
-func (ndb *nodeDB) updateBranchForFastNode(additions map[string]*FastNode, removals map[string]interface{}) {
+func (ndb *nodeDB) updateBranchForFastNode(fnc *fastNodeChanges) {
 	ndb.mtx.Lock()
-	for k, v := range additions {
-		ndb.prePersistFastNode.add(k, v)
-	}
-	for k, v := range removals {
-		ndb.prePersistFastNode.remove(k, v)
-	}
+	ndb.prePersistFastNode.mergeLater(fnc)
 	ndb.mtx.Unlock()
 }
 

--- a/libs/iavl/unsaved_fast_iterator_okc.go
+++ b/libs/iavl/unsaved_fast_iterator_okc.go
@@ -8,22 +8,18 @@ type UnsavedFastIteratorWithCache struct {
 
 var _ dbm.Iterator = (*UnsavedFastIteratorWithCache)(nil)
 
-func NewUnsavedFastIteratorWithCache(start, end []byte, ascending bool, ndb *nodeDB, unsavedFastNodeAdditions map[string]*FastNode, unsavedFastNodeRemovals map[string]interface{}) *UnsavedFastIteratorWithCache {
+func NewUnsavedFastIteratorWithCache(start, end []byte, ascending bool, ndb *nodeDB, fncIn *fastNodeChanges) *UnsavedFastIteratorWithCache {
 	iter := &UnsavedFastIteratorWithCache{
 		UnsavedFastIterator: &UnsavedFastIterator{},
 	}
 
-	if ndb == nil || unsavedFastNodeAdditions == nil || unsavedFastNodeRemovals == nil {
-		iter.UnsavedFastIterator = newUnsavedFastIterator(start, end, ascending, ndb, unsavedFastNodeAdditions, unsavedFastNodeRemovals)
+	fnc := fncIn.clone()
+	if ndb == nil || fnc.additions == nil || fnc.removals == nil {
+		iter.UnsavedFastIterator = newUnsavedFastIterator(start, end, ascending, ndb, fnc.additions, fnc.removals)
 		return iter
 	}
 
-	fnc := &fastNodeChanges{
-		additions: unsavedFastNodeAdditions,
-		removals:  unsavedFastNodeRemovals,
-	}
-	fnc = fnc.clone()
-	fnc.merge(ndb.prePersistFastNode)
+	fnc.mergePrev(ndb.prePersistFastNode)
 
 	if ndb.tpfv != nil {
 		fnc = ndb.tpfv.expand(fnc)

--- a/libs/tendermint/mempool/clist_mempool.go
+++ b/libs/tendermint/mempool/clist_mempool.go
@@ -268,6 +268,10 @@ func (mem *CListMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo Tx
 	}
 	// END CACHE
 
+	mem.updateMtx.RLock()
+	// use defer to unlock mutex because application (*local client*) might panic
+	defer mem.updateMtx.RUnlock()
+
 	var err error
 	var gasUsed int64
 	if cfg.DynamicConfig.GetMaxGasUsedPerBlock() > -1 {
@@ -280,10 +284,6 @@ func (mem *CListMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo Tx
 			gasUsed = int64(simuRes.GasUsed)
 		}
 	}
-
-	mem.updateMtx.RLock()
-	// use defer to unlock mutex because application (*local client*) might panic
-	defer mem.updateMtx.RUnlock()
 
 	if mem.preCheck != nil {
 		if err = mem.preCheck(tx); err != nil {


### PR DESCRIPTION
add unittest for the concurrent set and get

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
