### PR TITLE
when dds' saveNodes empty. we dont add root to saveNodes

### DIFF
--- a/libs/cosmos-sdk/store/iavl/store_test.go
+++ b/libs/cosmos-sdk/store/iavl/store_test.go
@@ -573,6 +573,8 @@ func testCommitDelta(t *testing.T) {
 	assert.Equal(t, emptyDelta, treeDelta)
 
 	// not use delta and produce delta
+	iavlStore.Set(k1, v1)
+	iavlStore.Set(k2, v2)
 	iavl.SetProduceDelta(true)
 	cid1, treeDelta1 := iavlStore.CommitterCommit(nil)
 	assert.NotEmpty(t, cid1.Hash)
@@ -637,6 +639,7 @@ func TestIAVLDelta(t *testing.T) {
 	assert.Equal(t, delta, emptyDelta)
 
 	// not use delta and produce delta
+	require.True(t, tree.Set([]byte("hello"), []byte("hallo")))
 	iavl.SetProduceDelta(true)
 	h1, v1, delta1, err := tree.SaveVersion(false)
 	require.NoError(t, err)

--- a/libs/iavl/mutable_tree.go
+++ b/libs/iavl/mutable_tree.go
@@ -851,8 +851,10 @@ func (tree *MutableTree) SaveVersionSync(version int64, useDeltas bool) ([]byte,
 		}
 		// generate state delta
 		if produceDelta {
-			delete(tree.savedNodes, amino.BytesToStr(tree.root.hash))
-			tree.savedNodes["root"] = tree.root
+			if len(tree.savedNodes) > 0 {
+				delete(tree.savedNodes, amino.BytesToStr(tree.root.hash))
+				tree.savedNodes["root"] = tree.root
+			}
 			tree.GetDelta()
 		}
 

--- a/libs/iavl/mutable_tree_oec.go
+++ b/libs/iavl/mutable_tree_oec.go
@@ -92,8 +92,10 @@ func (tree *MutableTree) SaveVersionAsync(version int64, useDeltas bool) ([]byte
 
 		// generate state delta
 		if produceDelta {
-			delete(tree.savedNodes, string(tree.root.hash))
-			tree.savedNodes["root"] = tree.root
+			if len(tree.savedNodes) > 0 {
+				delete(tree.savedNodes, string(tree.root.hash))
+				tree.savedNodes["root"] = tree.root
+			}
 			tree.GetDelta()
 		}
 	}

--- a/libs/iavl/mutable_tree_test.go
+++ b/libs/iavl/mutable_tree_test.go
@@ -271,7 +271,6 @@ func TestMutableTree_SaveVersionDelta(t *testing.T) {
 	require.NoError(t, err)
 
 	tree.Set([]byte("a"), []byte{0x01})
-
 	// not use delta and not produce delta
 	h, v, delta, err := tree.SaveVersion(false)
 	require.NoError(t, err)
@@ -279,6 +278,7 @@ func TestMutableTree_SaveVersionDelta(t *testing.T) {
 	assert.EqualValues(t, 9, v)
 	assert.Equal(t, delta, emptyDelta)
 
+	tree.Set([]byte("a"), []byte{0x01})
 	// not use delta and produce delta
 	SetProduceDelta(true)
 	h1, v1, delta1, err := tree.SaveVersion(false)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
