### PR TITLE
fix feesplit cache contaminate when parallel-tx rerun

### DIFF
--- a/app/app_parallel.go
+++ b/app/app_parallel.go
@@ -132,9 +132,14 @@ type feeSplitInfo struct {
 }
 
 func updateFeeSplitHandler(txFeesplit *sync.Map) sdk.UpdateFeeSplitHandler {
-	return func(txHash common.Hash, withdrawer sdk.AccAddress, fee sdk.Coins) {
-		// For rerun tx of parallel, feeSplitInfo is rewritten
-		txFeesplit.Store(txHash.String(), feeSplitInfo{withdrawer.String(), fee})
+	return func(txHash common.Hash, withdrawer sdk.AccAddress, fee sdk.Coins, isDelete bool) {
+		if isDelete {
+			// For rerun tx of parallel, feeSplitInfo is deleted when EnableFeeSplit is false
+			txFeesplit.Delete(txHash.String())
+		} else {
+			// For rerun tx of parallel, feeSplitInfo is rewritten when EnableFeeSplit is true
+			txFeesplit.Store(txHash.String(), feeSplitInfo{withdrawer.String(), fee})
+		}
 	}
 }
 

--- a/libs/cosmos-sdk/types/handler.go
+++ b/libs/cosmos-sdk/types/handler.go
@@ -26,7 +26,7 @@ type EvmSysContractAddressHandler func(ctx Context, addr AccAddress) bool
 type UpdateFeeCollectorAccHandler func(ctx Context, balance Coins, txFeesplit *sync.Map) error
 
 type LogFix func(tx []Tx, logIndex []int, hasEnterEvmTx []bool, errs []error, resp []abci.ResponseDeliverTx) (logs [][]byte)
-type UpdateFeeSplitHandler func(txHash common.Hash, addr AccAddress, fee Coins)
+type UpdateFeeSplitHandler func(txHash common.Hash, addr AccAddress, fee Coins, isDelete bool)
 type GetTxFeeAndFromHandler func(ctx Context, tx Tx) (Coins, bool, string, string, error)
 type GetTxFeeHandler func(tx Tx) Coins
 

--- a/x/feesplit/keeper/evm_hooks.go
+++ b/x/feesplit/keeper/evm_hooks.go
@@ -58,6 +58,8 @@ func (k Keeper) PostTxProcessing(
 	// check if the fees are globally enabled
 	params := k.GetParamsWithCache(ctx)
 	if !params.EnableFeeSplit {
+		// delete feesplit info
+		k.updateFeeSplitHandler(receipt.TxHash, nil, nil, true)
 		return nil
 	}
 
@@ -95,7 +97,7 @@ func (k Keeper) PostTxProcessing(
 	fees := sdk.Coins{{Denom: sdk.DefaultBondDenom, Amount: developerFee}}
 
 	// distribute the fees to the contract deployer / withdraw address
-	k.updateFeeSplitHandler(receipt.TxHash, withdrawer, fees)
+	k.updateFeeSplitHandler(receipt.TxHash, withdrawer, fees, false)
 
 	// add innertx
 	k.addFeesplitInnerTx(receipt.TxHash.Hex(), withdrawer.String(), fees.String())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
