### PR TITLE
applybolck workload statistic

### DIFF
--- a/app/elapse_info.go
+++ b/app/elapse_info.go
@@ -2,10 +2,11 @@ package app
 
 import (
 	"fmt"
-	"github.com/okex/exchain/libs/system/trace"
-	"github.com/okex/exchain/libs/tendermint/libs/log"
 	"strings"
 	"sync"
+
+	"github.com/okex/exchain/libs/system/trace"
+	"github.com/okex/exchain/libs/tendermint/libs/log"
 
 	"github.com/spf13/viper"
 )
@@ -54,6 +55,7 @@ var (
 		trace.RunTx,
 		trace.Prerun,
 		trace.MempoolTxsCnt,
+		trace.Workload,
 	}
 
 	DefaultElapsedSchemas string

--- a/libs/system/trace/schema.go
+++ b/libs/system/trace/schema.go
@@ -30,7 +30,6 @@ const (
 	HandlerDefer = "handler_defer"
 )
 
-
 const (
 	GasUsed     = "GasUsed"
 	Produce     = "Produce"
@@ -78,6 +77,8 @@ const (
 	IavlRuntime     = "IavlRuntime"
 
 	BlockPartsP2P = "BlockPartsP2P"
+
+	Workload = "Workload"
 )
 
 const (

--- a/libs/system/trace/trace.go
+++ b/libs/system/trace/trace.go
@@ -33,8 +33,10 @@ type Tracer struct {
 	intervals        []time.Duration
 	elapsedTime      time.Duration
 
-	pinMap map[string]time.Duration
-	enableSummary    bool
+	pinMap        map[string]time.Duration
+	enableSummary bool
+
+	wls *WorkloadStatistic
 }
 
 func NewTracer(name string) *Tracer {
@@ -48,6 +50,10 @@ func NewTracer(name string) *Tracer {
 
 func (t *Tracer) EnableSummary() {
 	t.enableSummary = true
+}
+
+func (t *Tracer) SetWorkloadStatistic(wls *WorkloadStatistic) {
+	t.wls = wls
 }
 
 func (t *Tracer) Pin(format string, args ...interface{}) {
@@ -67,12 +73,20 @@ func (t *Tracer) pinByFormat(tag string) {
 
 	now := time.Now()
 
+	if t.wls != nil {
+		t.wls.begin(tag, now)
+	}
+
 	if len(t.lastPin) > 0 {
 		t.pins = append(t.pins, t.lastPin)
 		duration := now.Sub(t.lastPinStartTime)
 		t.intervals = append(t.intervals, duration)
 		if t.enableSummary {
 			insertElapse(t.lastPin, duration.Milliseconds())
+		}
+
+		if t.wls != nil {
+			t.wls.end(tag, now)
 		}
 	}
 	t.lastPinStartTime = now

--- a/libs/system/trace/trace.go
+++ b/libs/system/trace/trace.go
@@ -86,7 +86,7 @@ func (t *Tracer) pinByFormat(tag string) {
 		}
 
 		if t.wls != nil {
-			t.wls.end(tag, now)
+			t.wls.end(t.lastPin, now)
 		}
 	}
 	t.lastPinStartTime = now

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -2,19 +2,17 @@ package trace
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 )
 
 var (
-	applyBlockWorkloadStatistic = newWorkloadStatistic([]time.Duration{time.Hour, 2 * time.Hour, 4 * time.Hour, 8 * time.Hour}, []string{LastRun, Persist})
+	applyBlockWorkloadStatistic = newWorkloadStatistic(
+		[]periodPair{{time.Hour, "1h"}, {2 * time.Hour, "2h"}, {4 * time.Hour, "4h"}, {8 * time.Hour, "8h"}}, []string{LastRun, Persist})
 )
 
-type workloadSummary struct {
-	period   time.Duration
-	workload atomic.Int64 // nano seconds
-	//oldest   *list.Element // element in `works` list
-}
+// TODO: think about a very long work which longer than a statistic period.
 
 // NOTE: CAN NOT be used concurrently for those reasons:
 // read/write almost all fields
@@ -25,9 +23,8 @@ type workloadSummary struct {
 // 2. calling begin/end before and after doing some work
 // 3. calling summary to get a summary statistic
 type WorkloadStatistic struct {
-	tags          map[string]struct{}
-	maximumPeriod time.Duration
-	workloads     []workloadSummary
+	tags      map[string]struct{}
+	workloads []workloadSummary
 
 	latestTag   string
 	latestBegin time.Time
@@ -35,8 +32,18 @@ type WorkloadStatistic struct {
 	workCh chan workInfo
 }
 
+type periodPair struct {
+	peirod time.Duration
+	name   string
+}
+
+type workloadSummary struct {
+	period   periodPair
+	workload atomic.Int64
+}
+
 type workInfo struct {
-	t        time.Time // TODO: begin time or end time?
+	end      time.Time
 	workload int64
 }
 
@@ -44,19 +51,39 @@ func GetApplyBlockWorkloadSttistic() *WorkloadStatistic {
 	return applyBlockWorkloadStatistic
 }
 
-func newWorkloadStatistic(periods []time.Duration, tags_ []string) *WorkloadStatistic {
+func newWorkloadStatistic(periods []periodPair, tags_ []string) *WorkloadStatistic {
 	tags := toTagsMap(tags_)
 
-	var maximumPeriod time.Duration
-	workloads := make([]workloadSummary, len(periods))
+	workloads := make([]workloadSummary, 0, len(periods))
 	for _, period := range periods {
 		workloads = append(workloads, workloadSummary{period, atomic.Int64{}})
-		if period > maximumPeriod {
-			maximumPeriod = period
-		}
 	}
 
-	return &WorkloadStatistic{tags: tags, maximumPeriod: maximumPeriod, workloads: workloads, workCh: make(chan workInfo)}
+	wls := &WorkloadStatistic{tags: tags, workloads: workloads, workCh: make(chan workInfo, 1000)}
+	go wls.shrink_loop()
+
+	return wls
+}
+
+func (ws *WorkloadStatistic) Add(tag string, wl time.Duration) {
+	if _, ok := ws.tags[tag]; !ok {
+		return
+	}
+
+	now := time.Now()
+	for i := range ws.workloads {
+		ws.workloads[i].workload.Add(int64(wl))
+		ws.workCh <- workInfo{now, int64(wl)}
+	}
+}
+
+func (ws *WorkloadStatistic) Format() string {
+	var sumItem []string
+	for _, summary := range ws.summary() {
+		sumItem = append(sumItem, fmt.Sprintf("%s<%.2f>", summary.period.name, float64(summary.workload)/float64(summary.period.peirod)))
+	}
+
+	return strings.Join(sumItem, ",")
 }
 
 func (ws *WorkloadStatistic) begin(tag string, t time.Time) {
@@ -69,26 +96,30 @@ func (ws *WorkloadStatistic) begin(tag string, t time.Time) {
 }
 
 func (ws *WorkloadStatistic) end(tag string, t time.Time) {
+	if _, ok := ws.tags[tag]; !ok {
+		return
+	}
 	assert(ws.latestTag == tag, "WorkloadStatistic: begin tag is %s but end tag is %s", ws.latestTag, tag)
 	assert(!ws.latestBegin.IsZero(), "WorkloadStatistic: begin is not called before end")
 
 	dur := t.Sub(ws.latestBegin)
-	for _, wload := range ws.workloads {
-		wload.workload.Add(int64(dur))
+	for i := range ws.workloads {
+		ws.workloads[i].workload.Add(int64(dur))
+		ws.workCh <- workInfo{t, int64(dur)}
 	}
 
 	ws.latestBegin = time.Time{}
 }
 
 type summaryInfo struct {
-	period   time.Duration
+	period   periodPair
 	workload time.Duration
 }
 
 func (ws *WorkloadStatistic) summary() []summaryInfo {
 	assert(ws.latestBegin.IsZero(), "WorkloadStatistic: some work is still running when calling summary")
 
-	summary := make([]summaryInfo, len(ws.workloads))
+	summary := make([]summaryInfo, 0, len(ws.workloads))
 	for _, wload := range ws.workloads {
 		summary = append(summary, summaryInfo{wload.period, time.Duration(wload.workload.Load())})
 	}
@@ -96,36 +127,38 @@ func (ws *WorkloadStatistic) summary() []summaryInfo {
 }
 
 func (ws *WorkloadStatistic) shrink_loop() {
-	type mywork struct {
-		t    time.Time
-		load int64
-	}
-
-	shrinkInfos := make([]map[int64]int64, len(ws.workloads))
+	shrinkInfos := make([]map[int64]int64, 0, len(ws.workloads))
 	for i := 0; i < len(ws.workloads); i++ {
 		shrinkInfos = append(shrinkInfos, make(map[int64]int64))
 	}
-	var latest int64
 
+	var latest int64
 	ticker := time.NewTicker(time.Second)
+
 	for {
 		select {
 		case work := <-ws.workCh:
-			if latest == 0 {
-				latest = work.t.Unix()
-			}
+			var earilest int64 = int64(^uint64(0) >> 1)
 
 			for i, wload := range ws.workloads {
 				period := wload.period
-				expired := work.t.Add(period)
-				expiredSec := expired.Unix()
+				expiredSec := work.end.Add(period.peirod).Unix()
+				if expiredSec < earilest {
+					earilest = expiredSec
+				}
 
 				info := shrinkInfos[i]
+				// TODO: it makes recoding workload larger than actual value
+				// if a work begin before this period and end during this period
 				if _, ok := info[expiredSec]; !ok {
 					info[expiredSec] = work.workload
 				} else {
 					info[expiredSec] += work.workload
 				}
+			}
+
+			if latest == 0 {
+				latest = earilest
 			}
 		case t := <-ticker.C:
 			current := t.Unix()
@@ -141,13 +174,15 @@ func (ws *WorkloadStatistic) shrink_loop() {
 					}
 				}
 			}
+
+			latest = current
 		}
 	}
 
 }
 
 func toTagsMap(keys []string) map[string]struct{} {
-	tags := make(map[string]struct{}, len(keys))
+	tags := make(map[string]struct{})
 	for _, tag := range keys {
 		tags[tag] = struct{}{}
 	}

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -1,0 +1,161 @@
+package trace
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	applyBlockWorkloadStatistic = newWorkloadStatistic([]time.Duration{time.Hour, 2 * time.Hour, 4 * time.Hour, 8 * time.Hour}, []string{LastRun, Persist})
+)
+
+type workloadSummary struct {
+	period   time.Duration
+	workload atomic.Int64 // nano seconds
+	//oldest   *list.Element // element in `works` list
+}
+
+// NOTE: CAN NOT be used concurrently for those reasons:
+// read/write almost all fields
+// workload summary may be wrong if a work is still running(latestBegin.IsZero isn't true)
+//
+// calling sequence:
+// 1. newWorkloadStatistic
+// 2. calling begin/end before and after doing some work
+// 3. calling summary to get a summary statistic
+type WorkloadStatistic struct {
+	tags          map[string]struct{}
+	maximumPeriod time.Duration
+	workloads     []workloadSummary
+
+	latestTag   string
+	latestBegin time.Time
+
+	workCh chan workInfo
+}
+
+type workInfo struct {
+	t        time.Time // TODO: begin time or end time?
+	workload int64
+}
+
+func GetApplyBlockWorkloadSttistic() *WorkloadStatistic {
+	return applyBlockWorkloadStatistic
+}
+
+func newWorkloadStatistic(periods []time.Duration, tags_ []string) *WorkloadStatistic {
+	tags := toTagsMap(tags_)
+
+	var maximumPeriod time.Duration
+	workloads := make([]workloadSummary, len(periods))
+	for _, period := range periods {
+		workloads = append(workloads, workloadSummary{period, atomic.Int64{}})
+		if period > maximumPeriod {
+			maximumPeriod = period
+		}
+	}
+
+	return &WorkloadStatistic{tags: tags, maximumPeriod: maximumPeriod, workloads: workloads, workCh: make(chan workInfo)}
+}
+
+func (ws *WorkloadStatistic) begin(tag string, t time.Time) {
+	if _, ok := ws.tags[tag]; !ok {
+		return
+	}
+
+	ws.latestTag = tag
+	ws.latestBegin = t
+}
+
+func (ws *WorkloadStatistic) end(tag string, t time.Time) {
+	assert(ws.latestTag == tag, "WorkloadStatistic: begin tag is %s but end tag is %s", ws.latestTag, tag)
+	assert(!ws.latestBegin.IsZero(), "WorkloadStatistic: begin is not called before end")
+
+	dur := t.Sub(ws.latestBegin)
+	for _, wload := range ws.workloads {
+		wload.workload.Add(int64(dur))
+	}
+
+	ws.latestBegin = time.Time{}
+}
+
+type summaryInfo struct {
+	period   time.Duration
+	workload time.Duration
+}
+
+func (ws *WorkloadStatistic) summary() []summaryInfo {
+	assert(ws.latestBegin.IsZero(), "WorkloadStatistic: some work is still running when calling summary")
+
+	summary := make([]summaryInfo, len(ws.workloads))
+	for _, wload := range ws.workloads {
+		summary = append(summary, summaryInfo{wload.period, time.Duration(wload.workload.Load())})
+	}
+	return summary
+}
+
+func (ws *WorkloadStatistic) shrink_loop() {
+	type mywork struct {
+		t    time.Time
+		load int64
+	}
+
+	shrinkInfos := make([]map[int64]int64, len(ws.workloads))
+	for i := 0; i < len(ws.workloads); i++ {
+		shrinkInfos = append(shrinkInfos, make(map[int64]int64))
+	}
+	var latest int64
+
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case work := <-ws.workCh:
+			if latest == 0 {
+				latest = work.t.Unix()
+			}
+
+			for i, wload := range ws.workloads {
+				period := wload.period
+				expired := work.t.Add(period)
+				expiredSec := expired.Unix()
+
+				info := shrinkInfos[i]
+				if _, ok := info[expiredSec]; !ok {
+					info[expiredSec] = work.workload
+				} else {
+					info[expiredSec] += work.workload
+				}
+			}
+		case t := <-ticker.C:
+			current := t.Unix()
+			if latest == 0 {
+				latest = current
+			}
+
+			for index, info := range shrinkInfos {
+				for i := latest; i < current+1; i++ {
+					w, ok := info[i]
+					if ok {
+						ws.workloads[index].workload.Add(-w)
+					}
+				}
+			}
+		}
+	}
+
+}
+
+func toTagsMap(keys []string) map[string]struct{} {
+	tags := make(map[string]struct{}, len(keys))
+	for _, tag := range keys {
+		tags[tag] = struct{}{}
+	}
+	return tags
+}
+
+func assert(b bool, msg string, args ...interface{}) {
+	if !b {
+		panic(fmt.Sprintf(msg, args...))
+	}
+}

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -223,7 +223,6 @@ func toTagsMap(keys []string) map[string]struct{} {
 func minDuration(d1 time.Duration, d2 time.Duration) time.Duration {
 	if d1 < d2 {
 		return d1
-	} else {
-		return d2
 	}
+	return d2
 }

--- a/libs/system/trace/workload_statistic_test.go
+++ b/libs/system/trace/workload_statistic_test.go
@@ -1,0 +1,37 @@
+package trace
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkload(t *testing.T) {
+	abciWorkload := time.Second
+	lastRunWorkload := 2 * time.Minute
+	persistWorkload := time.Second
+	expectWorkload := int64((lastRunWorkload + persistWorkload).Seconds())
+
+	trc := NewTracer(ApplyBlock)
+	trc.EnableSummary()
+	trc.SetWorkloadStatistic(GetApplyBlockWorkloadSttistic())
+
+	defer func() {
+		GetElapsedInfo().AddInfo(RunTx, trc.Format())
+
+		summary := GetApplyBlockWorkloadSttistic().summary()
+		for _, sum := range summary {
+			workload := int64(sum.workload.Seconds())
+			if workload != expectWorkload {
+				t.Errorf("period %s: expect workload %v but got %v\n", sum.period.peirod, expectWorkload, workload)
+			}
+		}
+	}()
+
+	trc.Pin(Abci)
+	time.Sleep(abciWorkload)
+	GetApplyBlockWorkloadSttistic().Add(LastRun, 2*time.Minute)
+
+	trc.Pin(Persist)
+	time.Sleep(time.Second)
+
+}

--- a/libs/system/trace/workload_statistic_test.go
+++ b/libs/system/trace/workload_statistic_test.go
@@ -18,20 +18,21 @@ func TestWorkload(t *testing.T) {
 	defer func() {
 		GetElapsedInfo().AddInfo(RunTx, trc.Format())
 
+		time.Sleep(time.Second)
 		summary := GetApplyBlockWorkloadSttistic().summary()
 		for _, sum := range summary {
 			workload := int64(sum.workload.Seconds())
 			if workload != expectWorkload {
-				t.Errorf("period %s: expect workload %v but got %v\n", sum.period.peirod, expectWorkload, workload)
+				t.Errorf("period %d: expect workload %v but got %v\n", sum.period, expectWorkload, workload)
 			}
 		}
 	}()
 
 	trc.Pin(Abci)
 	time.Sleep(abciWorkload)
-	GetApplyBlockWorkloadSttistic().Add(LastRun, 2*time.Minute)
+	GetApplyBlockWorkloadSttistic().Add(LastRun, lastRunWorkload)
 
 	trc.Pin(Persist)
-	time.Sleep(time.Second)
+	time.Sleep(persistWorkload)
 
 }

--- a/libs/tendermint/state/execution.go
+++ b/libs/tendermint/state/execution.go
@@ -220,8 +220,8 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		trace.GetElapsedInfo().AddInfo(trace.Tx, strconv.Itoa(len(block.Data.Txs)))
 		trace.GetElapsedInfo().AddInfo(trace.BlockSize, strconv.Itoa(block.FastSize()))
 		trace.GetElapsedInfo().AddInfo(trace.RunTx, trc.Format())
+		trace.GetElapsedInfo().AddInfo(trace.Workload, blockExec.wls.Format())
 		trace.GetElapsedInfo().SetElapsedTime(trc.GetElapsedTime())
-		// TODO
 
 		now := time.Now().UnixNano()
 		blockExec.metrics.IntervalTime.Set(float64(now-blockExec.metrics.lastBlockTime) / 1e6)
@@ -244,6 +244,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	abciResponses, duration, err := blockExec.runAbci(block, deltaInfo)
 
 	trace.GetElapsedInfo().AddInfo(trace.LastRun, fmt.Sprintf("%dms", duration.Milliseconds()))
+	blockExec.wls.Add(trace.LastRun, duration)
 
 	if err != nil {
 		return state, 0, ErrProxyAppConn(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

统计在指定时间内（1h, 2h, 4h, 8h） ApplyBlock 中 LastRun 和 Persist 的工作时长占比，输出于日志 `Workload` 字段中
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
