### PR TITLE
Workload: fix concurrency execute bug

### DIFF
--- a/libs/system/trace/trace.go
+++ b/libs/system/trace/trace.go
@@ -73,10 +73,6 @@ func (t *Tracer) pinByFormat(tag string) {
 
 	now := time.Now()
 
-	if t.wls != nil {
-		t.wls.begin(tag, now)
-	}
-
 	if len(t.lastPin) > 0 {
 		t.pins = append(t.pins, t.lastPin)
 		duration := now.Sub(t.lastPinStartTime)
@@ -86,7 +82,7 @@ func (t *Tracer) pinByFormat(tag string) {
 		}
 
 		if t.wls != nil {
-			t.wls.end(t.lastPin, now)
+			t.wls.Add(t.lastPin, now, duration)
 		}
 	}
 	t.lastPinStartTime = now

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -40,6 +40,8 @@ type singleWorkInfo struct {
 	endTime  time.Time
 }
 
+// GetApplyBlockWorkloadSttistic return a global `WorkloadStatistic` object.
+// WARNING: if you call `WorkloadStatistic.Add` concurrently, the summary result will be incorrect.
 func GetApplyBlockWorkloadSttistic() *WorkloadStatistic {
 	return applyBlockWorkloadStatistic
 }
@@ -58,6 +60,8 @@ func newWorkloadStatistic(periods []time.Duration, tags []string) *WorkloadStati
 	return wls
 }
 
+// Add accumulate workload to summary.
+// WARNING: if you call `Add` concurrently, the summary result will be incorrect.
 func (ws *WorkloadStatistic) Add(tag string, endTime time.Time, duration time.Duration) {
 	if _, ok := ws.concernedTags[tag]; !ok {
 		return

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"github.com/okex/exchain/libs/tendermint/libs/log"
 )
 
 var (
@@ -37,10 +35,6 @@ var (
 type WorkloadStatistic struct {
 	concernedTags map[string]struct{}
 	summaries     []workloadSummary
-
-	latestTag   string
-	latestBegin time.Time
-	logger      log.Logger
 
 	workCh chan singleWorkInfo
 }
@@ -73,21 +67,16 @@ func newWorkloadStatistic(periods []time.Duration, tags []string) *WorkloadStati
 	return wls
 }
 
-func (ws *WorkloadStatistic) SetLogger(logger log.Logger) {
-	ws.logger = logger
-}
-
-func (ws *WorkloadStatistic) Add(tag string, dur time.Duration) {
+func (ws *WorkloadStatistic) Add(tag string, endTime time.Time, duration time.Duration) {
 	if _, ok := ws.concernedTags[tag]; !ok {
 		return
 	}
 
-	now := time.Now()
 	for i := range ws.summaries {
-		atomic.AddInt64(&ws.summaries[i].workload, int64(dur))
+		atomic.AddInt64(&ws.summaries[i].workload, int64(duration))
 	}
 
-	ws.workCh <- singleWorkInfo{int64(dur), now}
+	ws.workCh <- singleWorkInfo{int64(duration), endTime}
 }
 
 func (ws *WorkloadStatistic) Format() string {
@@ -99,49 +88,12 @@ func (ws *WorkloadStatistic) Format() string {
 	return strings.Join(sumItem, "|")
 }
 
-func (ws *WorkloadStatistic) begin(tag string, t time.Time) {
-	if _, ok := ws.concernedTags[tag]; !ok {
-		return
-	}
-
-	ws.latestTag = tag
-	ws.latestBegin = t
-}
-
-func (ws *WorkloadStatistic) end(tag string, t time.Time) {
-	if _, ok := ws.concernedTags[tag]; !ok {
-		return
-	}
-
-	if ws.latestTag != tag {
-		ws.logger.Error("WorkloadStatistic", ": begin tag", ws.latestTag, "end tag", tag)
-		return
-	}
-	if ws.latestBegin.IsZero() {
-		ws.logger.Error("WorkloadStatistic", "begin is not called before end")
-		return
-	}
-
-	dur := t.Sub(ws.latestBegin)
-	for i := range ws.summaries {
-		atomic.AddInt64(&ws.summaries[i].workload, int64(dur))
-	}
-
-	ws.workCh <- singleWorkInfo{int64(dur), t}
-	ws.latestBegin = time.Time{}
-}
-
 type summaryInfo struct {
 	period   time.Duration
 	workload time.Duration
 }
 
 func (ws *WorkloadStatistic) summary() []summaryInfo {
-	if !ws.latestBegin.IsZero() {
-		ws.logger.Error("WorkloadStatistic", ": some work is still running when calling summary")
-		return nil
-	}
-
 	startupDuration := time.Now().Sub(startupTime)
 	result := make([]summaryInfo, 0, len(ws.summaries))
 

--- a/libs/system/trace/workload_statistic.go
+++ b/libs/system/trace/workload_statistic.go
@@ -23,15 +23,6 @@ var (
 // out-of-date timestamp; `shrinkLoop` also has a ticker promote current time once a second.
 // If current time is larger or equal than recorded timestamp, it remove that workload and subtract
 // it's value from `summaries`.
-//
-// NOTE: CAN NOT use `WorkloadStatistic` concurrently for those reasons:
-// read/write almost all fields
-// workload summary may be wrong if a work is still running(latestBegin.IsZero isn't true)
-//
-// calling sequence:
-// 1. newWorkloadStatistic
-// 2. calling begin/end before and after doing some work
-// 3. calling summary to get a summary statistic
 type WorkloadStatistic struct {
 	concernedTags map[string]struct{}
 	summaries     []workloadSummary

--- a/libs/system/trace/workload_statistic_test.go
+++ b/libs/system/trace/workload_statistic_test.go
@@ -30,7 +30,7 @@ func TestWorkload(t *testing.T) {
 
 	trc.Pin(Abci)
 	time.Sleep(abciWorkload)
-	GetApplyBlockWorkloadSttistic().Add(LastRun, lastRunWorkload)
+	GetApplyBlockWorkloadSttistic().Add(LastRun, time.Now(), lastRunWorkload)
 
 	trc.Pin(Persist)
 	time.Sleep(persistWorkload)

--- a/libs/tendermint/state/execution.go
+++ b/libs/tendermint/state/execution.go
@@ -240,7 +240,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	abciResponses, duration, err := blockExec.runAbci(block, deltaInfo)
 
 	trace.GetElapsedInfo().AddInfo(trace.LastRun, fmt.Sprintf("%dms", duration.Milliseconds()))
-	trace.GetApplyBlockWorkloadSttistic().Add(trace.LastRun, duration)
+	trace.GetApplyBlockWorkloadSttistic().Add(trace.LastRun, time.Now(), duration)
 
 	if err != nil {
 		return state, 0, ErrProxyAppConn(err)


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

`WorkloadStatistic` 之前的逻辑不支持并发，但在测试用例 `TestFastSyncBadBlockStopsPeer` 中并发执行 `ApplyBlock` ，导致 `WorkloadStatistic` 崩溃。
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
