### PR TITLE
fix UnmarshalGuFactor bug for extra is "{} or {"gufactor1":"0.1"}" for mpt

### DIFF
--- a/x/evm/types/gu_factor.go
+++ b/x/evm/types/gu_factor.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -28,6 +29,9 @@ func (factor GuFactor) ValidateBasic() error {
 func UnmarshalGuFactor(data string) (GuFactor, error) {
 	var factor GuFactor
 	err := json.Unmarshal([]byte(data), &factor)
+	if factor.Factor.IsNil() {
+		return factor, fmt.Errorf("json unmarshal failed: %v", err)
+	}
 	return factor, err
 }
 

--- a/x/evm/types/gu_factor_test.go
+++ b/x/evm/types/gu_factor_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	sdk "github.com/okex/exchain/libs/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -13,7 +14,56 @@ func TestMarshalGuFactor(t *testing.T) {
 
 	result := factor.Factor.MulInt(sdk.NewIntFromUint64(1220)).TruncateInt().Uint64()
 	t.Log("result", result)
+	require.Equal(t, uint64(7320000), result)
 
 	t.Log("-1", sdk.NewDec(-1).String(), sdk.NewDec(-1).IsNegative())
+	str = "{\"gu_factor1\":\"6000.000000000000000000\"}"
+	factor, err = UnmarshalGuFactor(str)
+	t.Log(fmt.Sprintf("errkey %s", err))
 
+	str = "{\"\":\"6000.000000000000000000\"}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("nonekey %s", err))
+
+	str = "{}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("nonedata %s", err))
+
+	str = "--"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("err data %s", err))
+
+	str = "{\"gu_factor\":\"6000.000000000000000000\",1}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("errjson %s", err))
+
+	str = "{\"gu_factor\":\"6000.0000000000000000000000\"}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("6000.0000000000000000000000 more lenght errnumber %s", err))
+
+	str = "{\"gu_factor\":\"600.0.0000000000000000000000\"}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("errnumber %s", err))
+
+	str = "{\"gu_factor\":\"a\"}"
+	factor, err = UnmarshalGuFactor(str)
+	require.Error(t, err)
+	t.Log(fmt.Sprintf("not a number %s", err))
+
+	str = "{\"gu_factor\":\"6000.000000000000000000\",\"gu_factor1\":\"599.000000000000000000\"}"
+	factor, err = UnmarshalGuFactor(str)
+	require.NoError(t, err)
+	t.Log("in64()", factor.Factor.Int64(), "TruncateInt64", factor.Factor.TruncateInt64(), "TruncateInt().Uint64", factor.Factor.TruncateInt().Uint64())
+	require.Equal(t, factor.Factor.TruncateInt().Uint64(), uint64(6000))
+
+	var ff GuFactor
+	require.NotNil(t, ff)
+	require.NotNil(t, ff.Factor)
+	require.Nil(t, ff.Factor.Int)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
