### PR TITLE
fix Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/app/start_from_snapshot.go
+++ b/app/start_from_snapshot.go
@@ -143,7 +143,14 @@ func extractTarGz(tarGzFile, destinationDir string) error {
 		if header == nil {
 			continue
 		}
-		target := filepath.Join(destinationDir, header.Name)
+		// Normalize the header name and ensure it does not escape the destination directory
+		cleanName := filepath.Clean(header.Name)
+		target := filepath.Join(destinationDir, cleanName)
+
+		// Ensure the target path is within the destination directory
+		if !strings.HasPrefix(target, filepath.Clean(destinationDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path: %s", header.Name)
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
https://github.com/okx/exchain/blob/1f43bef3e9cfdfe5d3bb4fcb968e067db0e4b623/app/start_from_snapshot.go#L136-L136

fix the issue need to validate the `header.Name` field to ensure it does not contain directory traversal sequences (`..`) or absolute paths. This can be achieved by:
1. Using `filepath.Clean` to normalize the path.
2. Verifying that the resulting path is within the intended `destinationDir` by checking that it has the `destinationDir` as its prefix.

The fix will involve:
- Normalizing `header.Name` using `filepath.Clean`.
- Constructing the full path using `filepath.Join`.
- Ensuring the resulting path is within `destinationDir` by comparing it with the intended directory prefix.



Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

if a zip file contains a file entry `..\okx-file`, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of `c:\output\..\okx-file`, which would cause the file to be written to `c:\okx-file`.

## POC
In this an archive is extracted without validating file paths. If `archive.zip` contained relative paths (for instance, if it were created by something like `zip archive.zip ../file.txt`) then executing this code could write to locations outside the destination directory.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"okx/exchain"
)

func unzip(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// BAD: This could overwrite any file on the file system
		ioutil.WriteFile(p, []byte("present"), 0666)
	}
}
```
To fix this vulnerability, we need to check that the path does not contain any "`..`" elements in it.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"okx/exchain"
	"strings"
)

func unzipGood(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// GOOD: Check that path does not contain ".." before using it
		if !strings.Contains(f.Name, "..") {
			ioutil.WriteFile(p, []byte("present"), 0666)
		}
	}
}
```
## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okexchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Reviewed `Files changed` in the github PR explorer

______


